### PR TITLE
fix: add path normaliser in lieu of pkg fix

### DIFF
--- a/.changeset/cyan-llamas-deny.md
+++ b/.changeset/cyan-llamas-deny.md
@@ -1,0 +1,5 @@
+---
+'gdu': patch
+---
+
+gdu: fix graph artifact paths for win32 for relay babel

--- a/packages/gdu/config/babel.config.js
+++ b/packages/gdu/config/babel.config.js
@@ -1,6 +1,8 @@
 /* eslint-disable unicorn/prefer-module */
 const { join } = require('path');
+
 const browsers = require('browserslist-config-autoguru');
+
 const { PROJECT_ROOT } = require('../lib/roots');
 
 module.exports = (guruConfig) => {

--- a/packages/gdu/config/babel.config.js
+++ b/packages/gdu/config/babel.config.js
@@ -1,9 +1,8 @@
 /* eslint-disable unicorn/prefer-module */
 const { join } = require('path');
-
 const browsers = require('browserslist-config-autoguru');
-
 const { PROJECT_ROOT } = require('../lib/roots');
+
 module.exports = (guruConfig) => {
 	let hasRelay = false;
 
@@ -60,6 +59,7 @@ module.exports = (guruConfig) => {
 				},
 			],
 			require.resolve('babel-plugin-treat'),
+			[ require.resolve('./pathNormaliser'), ],
 		].filter(Boolean),
 	};
 };

--- a/packages/gdu/config/pathNormaliser.js
+++ b/packages/gdu/config/pathNormaliser.js
@@ -1,5 +1,4 @@
-'use strict';
-
+/* eslint-disable unicorn/prefer-module */
 const replacer = (filepath) => filepath.replace(/\\/g, '/');
 
 /**

--- a/packages/gdu/config/pathNormaliser.js
+++ b/packages/gdu/config/pathNormaliser.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const replacer = (filepath) => filepath.replace(/\\/g, '/');
+
+/**
+ * Normalise path to POSIX (only for `win32` using `require`).
+ */
+const PathNormaliserPlugin = function (api) {
+  if (process.platform === 'win32') {
+    const t = api.types;
+
+    return {
+      name: 'path-normaliser',
+
+      visitor: {
+        CallExpression: {
+          enter: function (nodePath) {
+            const callee = nodePath.get('callee');
+
+            if (callee.isIdentifier() && callee.equals('name', 'require')) {
+              const arg = nodePath.get('arguments.0');
+
+              if (arg && arg.isStringLiteral()) {
+                const sourcePath = arg.node.value;
+                const targetPath = replacer(sourcePath);
+
+                if (sourcePath !== targetPath) {
+                  arg.replaceWith(t.stringLiteral(targetPath));
+                }
+              }
+            }
+          },
+        },
+      },
+    };
+  }
+
+  return {
+    name: 'path-normaliser',
+  };
+};
+
+module.exports = PathNormaliserPlugin;


### PR DESCRIPTION
https://github.com/facebook/relay/issues/3272

Also fixed if package is manually patched as follows:
```
relay/packages/babel-plugin-relay/compileGraphQLTag.js
-  return relativeReference + joinPath(relative, fileToRequire); 
+  return relativeReference + joinPath(relative, fileToRequire).replace(/\\/g, '/'); // required for win32
```
^ Obviously this isn't viable. Have tested the workaround included here on Windows, will require testing on Mac.
Additionally I suppose we can bump this issue thread as it still seems to be open.