### PR TITLE
chore: Adds new tenant, environment and mfe types

### DIFF
--- a/.changeset/chilled-plums-switch.md
+++ b/.changeset/chilled-plums-switch.md
@@ -1,0 +1,5 @@
+---
+'gdu': minor
+---
+
+Adds new tenant, environment and mfe types

--- a/packages/gdu/commands/global-configs/config-tenants.ts
+++ b/packages/gdu/commands/global-configs/config-tenants.ts
@@ -5,8 +5,8 @@ import * as dotenv from 'dotenv';
 
 import { getTokens } from '../../lib/globalConfigs';
 
-const envs = ['uat', 'preprod', 'dev', 'prod', 'test', 'tokens'];
-const tenants = ['au', 'nz', 'au-legacy'];
+const envs = ['uat', 'preprod', 'dev', 'prod', 'test', 'tokens', 'shared'];
+const tenants = ['au', 'nz', 'au-legacy', 'global'];
 type ENV = (typeof envs)[number];
 type TENANT = (typeof tenants)[number] ;
 

--- a/packages/gdu/commands/global-configs/config-tokens.ts
+++ b/packages/gdu/commands/global-configs/config-tokens.ts
@@ -5,8 +5,8 @@ import * as dotenv from 'dotenv';
 
 import { getTokens } from '../../lib/globalConfigs';
 
-const envs = ['uat', 'preprod', 'dev', 'prod_build', 'test', 'tokens'];
-const tenants = ['au', 'nz', 'au-legacy'];
+const envs = ['uat', 'preprod', 'dev', 'prod_build', 'test', 'tokens', 'shared'];
+const tenants = ['au', 'nz', 'au-legacy', 'global'];
 type ENV = (typeof envs)[number];
 type TENANT = (typeof tenants)[number] ;
 

--- a/packages/gdu/commands/mfe-list/generate-mfe-list.ts
+++ b/packages/gdu/commands/mfe-list/generate-mfe-list.ts
@@ -6,8 +6,9 @@ const tenantsList = [
 	'au',
 	'au-legacy',
 	'nz',
+	'global'
 ]
-const envs = ['dev', 'uat', 'test', 'preprod', 'prod'];
+const envs = ['dev', 'uat', 'test', 'preprod', 'prod', 'shared'];
 
 function checkTenantsEnvs(appsDir, directory) {
 	const appConfig = path.resolve(appsDir, directory, '.gdu_app_config');

--- a/packages/gdu/config/next.config.ts
+++ b/packages/gdu/config/next.config.ts
@@ -208,7 +208,7 @@ export const defaultSecurityHeaders = [
 	},
 ];
 
-const productionEnvs = new Set(['prod', 'dockerprod', 'preprod']);
+const productionEnvs = new Set(['prod', 'dockerprod', 'preprod', 'shared']);
 
 export const createNextJSConfig = (
 	buildEnv,

--- a/packages/gdu/lib/config.ts
+++ b/packages/gdu/lib/config.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, join, basename } from 'path';
+import { basename, isAbsolute, join } from 'path';
 
 import { diary } from 'diary';
 
@@ -14,7 +14,9 @@ export interface GuruConfig {
 		| 'ssr'
 		| 'spa'
 		| 'serverless'
+		| 'serverless-cdk'
 		| 'serverless-resource'
+		// @deprecated migrate serverless-resource SAM CLI stacks to AWS cdk
 		| 'web-component';
 	mountDOMId?: string;
 	mountDOMClass?: string;

--- a/packages/gdu/utils/configs.ts
+++ b/packages/gdu/utils/configs.ts
@@ -3,7 +3,7 @@ import findUp from 'find-up';
 import { APP_ENV } from '../gdu';
 
 export const getBuildEnvs = (env: APP_ENV) =>
-	env ? [env] : ['uat', 'preprod', 'dockerprod', 'prod'];
+	env ? [env] : ['uat', 'preprod', 'dockerprod', 'prod', 'shared'];
 export const getConfigsDirs = () =>
 	[
 		findUp.sync('.gdu_config', { type: 'directory' }),


### PR DESCRIPTION
Here’s a summary of the changes in this pull request. We’re adding new tenant, environment, and MFE types, and making some minor refactoring. The most important changes are listed below.

### Addition of new tenant and environment types:

* [`packages/gdu/commands/global-configs/config-tenants.ts`](diffhunk://#diff-ee853396f6bc772fc06cf5608a1767fb489c6ae0b5e93b283f7c3657c78ddab5L8-R9): Added 'shared' to `envs` and 'global' to `tenants`.
* [`packages/gdu/commands/global-configs/config-tokens.ts`](diffhunk://#diff-811f84ada962606c1d97631df41c674ada109eafb5c9d3120f7ecc8d301a5195L8-R9): Added 'shared' to `envs` and 'global' to `tenants`.
* [`packages/gdu/commands/mfe-list/generate-mfe-list.ts`](diffhunk://#diff-ea6e19b6d6fcaafda32adae9774a523c787564dcb7ba53295d04f5c002bdb103R9-R11): Added 'global' to `tenantsList` and 'shared' to `envs`.
* [`packages/gdu/config/next.config.ts`](diffhunk://#diff-cef2a153719e059ffed87382cfbfb25baf73ec9c657d8a85c763a6a24581f3bdL211-R211): Added 'shared' to `productionEnvs`.
* [`packages/gdu/utils/configs.ts`](diffhunk://#diff-dab0fdaaebcd7b7a0103b012ee74a52e8640b6962b507ffc0421b887b11268f0L6-R6): Added 'shared' to the default environment list in `getBuildEnvs`.

### Minor refactoring:

* [`packages/gdu/lib/config.ts`](diffhunk://#diff-10c363a2c1197c57aa9ca3757970856b7c963ed88fc354c86e741e86e0157302L1-R1): Reordered imports and added a new type 'serverless-cdk' to `GuruConfig`, with a deprecation comment for 'serverless-resource'. [[1]](diffhunk://#diff-10c363a2c1197c57aa9ca3757970856b7c963ed88fc354c86e741e86e0157302L1-R1) [[2]](diffhunk://#diff-10c363a2c1197c57aa9ca3757970856b7c963ed88fc354c86e741e86e0157302R17-R19)