### PR TITLE
chore: Updates MFE lb priority offset

### DIFF
--- a/.changeset/famous-emus-judge.md
+++ b/.changeset/famous-emus-judge.md
@@ -1,0 +1,5 @@
+---
+'gdu': minor
+---
+
+Updates MFE lb priority offset

--- a/packages/gdu/commands/global-configs/config-tenants.ts
+++ b/packages/gdu/commands/global-configs/config-tenants.ts
@@ -26,7 +26,7 @@ const scopeOffsets: Record<string, number> = {
 	'au-legacy': 2,
 };
 
-const mfeApplicationOffset = 500;
+const mfeApplicationOffset = 0;
 
 const mapLBPriority = (value: string, env: ENV, tenant?: TENANT) => {
 	const envOffset = environmentOffsets[env.toLowerCase()] ?? 0;


### PR DESCRIPTION
This pull request includes changes to update the MFE load balancer priority offset. The most important changes are as follows:

Updates to MFE load balancer priority offset:

* [`.changeset/famous-emus-judge.md`](diffhunk://#diff-af47eef723c72f4fdebf42e349cd65a69c311322c88595b8624dd5286e6f7f6bR1-R5): Added a changeset file to document the minor update to the MFE load balancer priority offset.
* [`packages/gdu/commands/global-configs/config-tenants.ts`](diffhunk://#diff-ee853396f6bc772fc06cf5608a1767fb489c6ae0b5e93b283f7c3657c78ddab5L29-R29): Changed the `mfeApplicationOffset` from 500 to 0.