### PR TITLE
Add test ci script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: yarn lint
 
       - name: Test
-        run: yarn test --no-cache --ci --coverage
+        run: yarn test:ci
 
       - uses: codecov/codecov-action@v1
         with:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 		"plop": "plop",
 		"build:all": "yarn workspace @autoguru/utilities build && nx run-many --target=build --all",
 		"release": "yarn run build:all && changeset publish",
-		"test": "jest"
+		"test": "jest",
+		"test:ci": "jest --no-cache --ci --coverage"
 	},
 	"resolutions": {
 		"@babel/core": "^7.24.5"


### PR DESCRIPTION
This pull request adds the new script `test:ci` for use in workflows so that the CLI flags are specific to the repo.