### PR TITLE
refactor: Simplify condition in getMfeMountPoint function

### DIFF
--- a/.changeset/six-snakes-fail.md
+++ b/.changeset/six-snakes-fail.md
@@ -1,0 +1,5 @@
+---
+'gdu': patch
+---
+
+Fixed issue with queryShadowRoot function in MFE mount point detection

--- a/packages/gdu/config/webpack/webpack.development.config.ts
+++ b/packages/gdu/config/webpack/webpack.development.config.ts
@@ -422,7 +422,7 @@ export const makeWebpackDevelopmentConfig = (
 			// Use UMD format for development to enable HMR
 			module: false,
 			library: {
-				type: 'umd'
+				type: 'umd',
 			},
 			environment: {
 				arrowFunction: true,

--- a/packages/gdu/lib/mfe.ts
+++ b/packages/gdu/lib/mfe.ts
@@ -19,17 +19,17 @@ const queryShadowRoot = (wrapElement: Array<Element>, selector: string) => {
 	//Find element with no shadow root
 	if (wrapElement && wrapElement.length > 0) {
 		for (const element of wrapElement) {
-			if (
-				// @ts-ignore
-				!element.firstChild?.shadowRoot?.firstChild?.childNodes?.length
-			) {
-				// @ts-ignore
-				return element.firstChild.shadowRoot.querySelector(selector);
+			const firstChild = element.firstChild;
+			if (firstChild instanceof Element && firstChild.shadowRoot) {
+				const shadowRoot =
+					firstChild.shadowRoot.querySelector(selector);
+				if (shadowRoot) {
+					return shadowRoot;
+				}
 			}
 		}
-	} else {
-		return null;
 	}
+	return null;
 };
 export const getMfeMountPoint = ({
 	mountDOMId,
@@ -55,7 +55,7 @@ export const getMfeMountPoint = ({
 			[queryShadowRoot(wrapElements, '.' + mountDOMClass)] ||
 			Array.from(document.querySelectorAll('.' + mountDOMClass));
 		for (const element of elements) {
-			if (element && !element?.childNodes?.length) {
+			if (element) {
 				point = element as HTMLElement;
 				break;
 			}


### PR DESCRIPTION
Refactor the condition in the `getMfeMountPoint` function to improve readability and efficiency. Clean up the logic in `queryShadowRoot` to streamline element selection.