### PR TITLE
chore: Ensures webpack respects APP_ENV values in build caches

### DIFF
--- a/packages/gdu/config/webpack/webpack.config.ts
+++ b/packages/gdu/config/webpack/webpack.config.ts
@@ -150,11 +150,17 @@ export const baseOptions = ({
 		cache: {
 			type: 'filesystem',
 			cacheLocation: resolve(PROJECT_ROOT, '.build_cache'),
+			name: process.env.APP_ENV || 'default',
 			allowCollectingMemory: false,
 			buildDependencies: {
 				// This makes all dependencies of this file - build dependencies
 				config: [__filename],
-				// By default webpack and loaders are build dependencies
+				// Add environment variables as build dependencies
+				env: [
+					process.env.APP_ENV,
+					process.env.NODE_ENV,
+					process.env.BABEL_DEBUG
+				].filter(Boolean),
 			},
 		},
 		resolve: {


### PR DESCRIPTION
This pull request updates the Webpack configuration in `packages/gdu/config/webpack/webpack.config.ts` to enhance caching and dependency tracking by incorporating environment variables.

Caching improvements:

* Added a `name` property to the cache configuration, which uses the `APP_ENV` environment variable or defaults to `'default'`.

Dependency tracking enhancements:

* Updated the `buildDependencies` configuration to include environment variables (`APP_ENV`, `NODE_ENV`, and `BABEL_DEBUG`) as dependencies, ensuring changes to these variables trigger a rebuild.