### PR TITLE
feat: Add TranslationHashingPlugin and i18n manifest configuration to webpack setup

### DIFF
--- a/.changeset/ready-boats-drop.md
+++ b/.changeset/ready-boats-drop.md
@@ -1,0 +1,5 @@
+---
+'gdu': minor
+---
+
+Adds support for hashing i18n translation files

--- a/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
+++ b/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
@@ -277,7 +277,7 @@ export const preloadLocales = async (locales = ['en']) => {
 
 // Initialize with detected locale
 export const initializeI18n = async () => {
-  const detectedLocale = (typeof navigator !== 'undefined' && navigator.language) 
+  const detectedLocale = (typeof navigator !== 'undefined' && typeof navigator.language === 'string' && navigator.language) 
     ? navigator.language.split('-')[0] 
     : 'en';
   

--- a/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
+++ b/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
@@ -265,7 +265,7 @@ export const preloadLocales = async (locales = ['en']) => {
   const promises = locales.map(locale => loadLocaleManifest(locale));
   const results = await Promise.allSettled(promises);
   
-  const loaded = {};
+  const loaded: Record<string, unknown | null> = {};
   results.forEach((result, index) => {
     if (result.status === 'fulfilled') {
       loaded[locales[index]] = result.value;

--- a/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
+++ b/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
@@ -1,0 +1,368 @@
+import crypto from 'crypto';
+import { promises as fs } from 'fs';
+import { existsSync } from 'fs';
+import path from 'path';
+import { Compiler, Compilation, sources } from 'webpack';
+
+interface TranslationInfo {
+  path: string;
+  hash: string;
+  size: number;
+}
+
+interface LocaleManifest {
+  [namespace: string]: TranslationInfo;
+}
+
+interface ManifestModule {
+  name: string;
+  hash: string;
+}
+
+interface PluginOptions {
+  publicPath?: string;
+  outputPath?: string;
+  localesDir?: string;
+  hashLength?: number;
+  excludeLocales?: string[];
+}
+
+const pluginName = 'TranslationHashingPlugin';
+
+export class TranslationHashingPlugin {
+  private options: Required<PluginOptions>;
+  private translationManifests: Map<string, LocaleManifest> = new Map();
+  private manifestModules: Map<string, ManifestModule> = new Map();
+
+  constructor(options: PluginOptions = {}) {
+    this.options = {
+      publicPath: options.publicPath || '/locales/',
+      outputPath: options.outputPath || 'locales/',
+      localesDir: options.localesDir || 'public/locales',
+      hashLength: options.hashLength || 8,
+      excludeLocales: options.excludeLocales || [],
+    };
+  }
+
+  apply(compiler: Compiler) {
+    compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
+      compilation.hooks.processAssets.tapAsync(
+        {
+          name: pluginName,
+          stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
+        },
+        async (_assets, callback) => {
+          try {
+            await this.processTranslations(compiler, compilation);
+            callback();
+          } catch (error) {
+            callback(error as Error);
+          }
+        }
+      );
+    });
+
+    // Hook into the emit phase to update the build manifest
+    compiler.hooks.emit.tapAsync(pluginName, async (compilation, callback) => {
+      try {
+        await this.updateBuildManifest(compilation);
+        callback();
+      } catch (error) {
+        callback(error as Error);
+      }
+    });
+  }
+
+  private async processTranslations(compiler: Compiler, compilation: Compilation) {
+    const localesPath = path.join(compiler.context, this.options.localesDir);
+    
+    if (!existsSync(localesPath)) {
+      console.log(`[${pluginName}] No locales directory found at ${localesPath}`);
+      return;
+    }
+
+    console.log(`[${pluginName}] Processing translations from ${localesPath}`);
+    
+    // Get all locale directories
+    const locales = await fs.readdir(localesPath);
+    
+    for (const locale of locales) {
+      if (this.options.excludeLocales.includes(locale)) {
+        continue;
+      }
+      
+      const localePath = path.join(localesPath, locale);
+      const stat = await fs.stat(localePath);
+      
+      if (stat.isDirectory()) {
+        const manifest = await this.processLocale(localePath, locale, compilation);
+        this.translationManifests.set(locale, manifest);
+      }
+    }
+
+    // Generate per-locale manifest modules
+    await this.generateManifestModules(compilation);
+    
+    // Generate master manifest module
+    await this.generateMasterManifest(compilation);
+  }
+
+  private async processLocale(
+    localePath: string,
+    locale: string,
+    compilation: Compilation
+  ): Promise<LocaleManifest> {
+    const manifest: LocaleManifest = {};
+    const files = await fs.readdir(localePath);
+    
+    for (const file of files) {
+      if (!file.endsWith('.json')) {
+        continue;
+      }
+      
+      const filePath = path.join(localePath, file);
+      const content = await fs.readFile(filePath, 'utf-8');
+      
+      // Generate content hash
+      const hash = crypto
+        .createHash('md5')
+        .update(content)
+        .digest('hex')
+        .substring(0, this.options.hashLength);
+      
+      const namespace = file.replace('.json', '');
+      const hashedFilename = `${namespace}.${hash}.json`;
+      const outputPath = path.join(this.options.outputPath, locale, hashedFilename);
+      
+      // Add to compilation assets
+      compilation.emitAsset(
+        outputPath,
+        new sources.RawSource(content, false)
+      );
+      
+      manifest[namespace] = {
+        path: `${this.options.publicPath}${locale}/${hashedFilename}`,
+        hash: hash,
+        size: content.length,
+      };
+      
+      console.log(`[${pluginName}] Processed ${locale}/${namespace} -> ${hashedFilename}`);
+    }
+    
+    return manifest;
+  }
+
+  private async generateManifestModules(compilation: Compilation) {
+    for (const [locale, manifest] of this.translationManifests.entries()) {
+      const moduleContent = this.createManifestModule(manifest);
+      const moduleHash = crypto
+        .createHash('md5')
+        .update(moduleContent)
+        .digest('hex')
+        .substring(0, this.options.hashLength);
+      
+      const moduleName = `i18n-manifest-${locale}.${moduleHash}.js`;
+      
+      compilation.emitAsset(
+        moduleName,
+        new sources.RawSource(moduleContent, false)
+      );
+      
+      this.manifestModules.set(locale, {
+        name: moduleName,
+        hash: moduleHash,
+      });
+      
+      console.log(`[${pluginName}] Generated manifest module: ${moduleName}`);
+    }
+  }
+
+  private createManifestModule(manifest: LocaleManifest): string {
+    return `// Auto-generated translation manifest
+export const manifest = ${JSON.stringify(manifest, null, 2)};
+
+export const getTranslationPath = (namespace) => {
+  const translation = manifest[namespace];
+  if (!translation) {
+    console.warn(\`Translation namespace "\${namespace}" not found in manifest\`);
+    return null;
+  }
+  return translation.path;
+};
+
+export const getTranslationHash = (namespace) => {
+  return manifest[namespace]?.hash;
+};
+
+export const getTranslationSize = (namespace) => {
+  return manifest[namespace]?.size;
+};
+
+export const getAllNamespaces = () => {
+  return Object.keys(manifest);
+};
+
+export const getManifestInfo = () => {
+  return {
+    namespaces: Object.keys(manifest),
+    totalSize: Object.values(manifest).reduce((sum, info) => sum + info.size, 0),
+    translations: manifest,
+  };
+};
+
+export default manifest;
+`;
+  }
+
+  private async generateMasterManifest(compilation: Compilation) {
+    const imports: string[] = [];
+    const mappings: string[] = [];
+    
+    for (const [locale, module] of this.manifestModules.entries()) {
+      imports.push(`import manifest_${locale} from './${module.name}';`);
+      mappings.push(`  '${locale}': () => import('./${module.name}')`);
+    }
+    
+    const masterContent = `// Auto-generated master translation manifest
+// Static imports for immediate availability
+${imports.join('\n')}
+
+// Dynamic imports for lazy loading
+export const translationManifests = {
+${mappings.join(',\n')}
+};
+
+// Static manifest access for SSR/preloading
+export const staticManifests = {
+${Array.from(this.manifestModules.keys()).map(locale => `  '${locale}': manifest_${locale}`).join(',\n')}
+};
+
+export const loadLocaleManifest = async (locale) => {
+  const loader = translationManifests[locale];
+  if (!loader) {
+    console.warn(\`Locale "\${locale}" not found in translation manifests\`);
+    return null;
+  }
+  
+  try {
+    const module = await loader();
+    return module.default || module.manifest;
+  } catch (error) {
+    console.error(\`Failed to load manifest for locale "\${locale}":\`, error);
+    return null;
+  }
+};
+
+export const getStaticManifest = (locale) => {
+  return staticManifests[locale] || null;
+};
+
+export const getSupportedLocales = () => {
+  return Object.keys(translationManifests);
+};
+
+export const preloadLocales = async (locales = ['en']) => {
+  const promises = locales.map(locale => loadLocaleManifest(locale));
+  const results = await Promise.allSettled(promises);
+  
+  const loaded = {};
+  results.forEach((result, index) => {
+    if (result.status === 'fulfilled') {
+      loaded[locales[index]] = result.value;
+    }
+  });
+  
+  return loaded;
+};
+
+// Initialize with detected locale
+export const initializeI18n = async () => {
+  const detectedLocale = (typeof navigator !== 'undefined' && navigator.language) 
+    ? navigator.language.split('-')[0] 
+    : 'en';
+  
+  const supportedLocales = getSupportedLocales();
+  const locale = supportedLocales.includes(detectedLocale) ? detectedLocale : 'en';
+  
+  return loadLocaleManifest(locale);
+};
+
+export default translationManifests;
+`;
+
+    const masterHash = crypto
+      .createHash('md5')
+      .update(masterContent)
+      .digest('hex')
+      .substring(0, this.options.hashLength);
+    
+    const masterName = `i18n-master-manifest.${masterHash}.js`;
+    
+    compilation.emitAsset(
+      masterName,
+      new sources.RawSource(masterContent, false)
+    );
+    
+    // Store the master manifest name for later use
+    compilation.hooks.afterProcessAssets.tap(pluginName, () => {
+      if (!compilation.assets['i18n-master-manifest.json']) {
+        const metaInfo = {
+          masterManifest: masterName,
+          manifestModules: Object.fromEntries(this.manifestModules),
+          locales: Array.from(this.translationManifests.keys()),
+          generated: new Date().toISOString(),
+        };
+        
+        compilation.emitAsset(
+          'i18n-master-manifest.json',
+          new sources.RawSource(JSON.stringify(metaInfo, null, 2), false)
+        );
+      }
+    });
+    
+    console.log(`[${pluginName}] Generated master manifest: ${masterName}`);
+  }
+
+  private async updateBuildManifest(compilation: Compilation) {
+    // Find the i18n master manifest metadata
+    const metaAsset = compilation.getAsset('i18n-master-manifest.json');
+    if (!metaAsset) {
+      return;
+    }
+    
+    const metaInfo = JSON.parse(metaAsset.source.source().toString());
+    
+    // Find and update the build manifest if it exists
+    const buildManifestAsset = compilation.getAsset('build-manifest.json');
+    if (buildManifestAsset) {
+      try {
+        const manifest = JSON.parse(buildManifestAsset.source.source().toString());
+        
+        // Add i18n information to the build manifest
+        manifest.i18n = {
+          masterManifest: metaInfo.masterManifest,
+          manifestModules: metaInfo.manifestModules,
+          supportedLocales: metaInfo.locales,
+          translationAssets: {},
+        };
+        
+        // Add translation file paths
+        for (const [locale, localeManifest] of this.translationManifests.entries()) {
+          manifest.i18n.translationAssets[locale] = {};
+          for (const [namespace, info] of Object.entries(localeManifest)) {
+            manifest.i18n.translationAssets[locale][namespace] = info.path;
+          }
+        }
+        
+        compilation.updateAsset(
+          'build-manifest.json',
+          new sources.RawSource(JSON.stringify(manifest, null, 2), false)
+        );
+        
+        console.log(`[${pluginName}] Updated build-manifest.json with i18n information`);
+      } catch (error) {
+        console.error(`[${pluginName}] Failed to update build manifest:`, error);
+      }
+    }
+  }
+}

--- a/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
+++ b/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
-import { promises as fs } from 'fs';
-import { existsSync } from 'fs';
+import { promises as fs , existsSync } from 'fs';
 import path from 'path';
+
 import { Compiler, Compilation, sources } from 'webpack';
 
 interface TranslationInfo {
@@ -75,25 +75,25 @@ export class TranslationHashingPlugin {
 
   private async processTranslations(compiler: Compiler, compilation: Compilation) {
     const localesPath = path.join(compiler.context, this.options.localesDir);
-    
+
     if (!existsSync(localesPath)) {
       console.log(`[${pluginName}] No locales directory found at ${localesPath}`);
       return;
     }
 
     console.log(`[${pluginName}] Processing translations from ${localesPath}`);
-    
+
     // Get all locale directories
     const locales = await fs.readdir(localesPath);
-    
+
     for (const locale of locales) {
       if (this.options.excludeLocales.includes(locale)) {
         continue;
       }
-      
+
       const localePath = path.join(localesPath, locale);
       const stat = await fs.stat(localePath);
-      
+
       if (stat.isDirectory()) {
         const manifest = await this.processLocale(localePath, locale, compilation);
         this.translationManifests.set(locale, manifest);
@@ -102,7 +102,7 @@ export class TranslationHashingPlugin {
 
     // Generate per-locale manifest modules
     await this.generateManifestModules(compilation);
-    
+
     // Generate master manifest module
     await this.generateMasterManifest(compilation);
   }
@@ -114,65 +114,67 @@ export class TranslationHashingPlugin {
   ): Promise<LocaleManifest> {
     const manifest: LocaleManifest = {};
     const files = await fs.readdir(localePath);
-    
+
     for (const file of files) {
       if (!file.endsWith('.json')) {
         continue;
       }
-      
+
       const filePath = path.join(localePath, file);
-      const content = await fs.readFile(filePath, 'utf-8');
-      
+      const content = await fs.readFile(filePath, 'utf8');
+
       // Generate content hash
+      // eslint-disable-next-line sonarjs/hashing
       const hash = crypto
         .createHash('md5')
         .update(content)
         .digest('hex')
-        .substring(0, this.options.hashLength);
-      
+        .slice(0, Math.max(0, this.options.hashLength));
+
       const namespace = file.replace('.json', '');
       const hashedFilename = `${namespace}.${hash}.json`;
       const outputPath = path.join(this.options.outputPath, locale, hashedFilename);
-      
+
       // Add to compilation assets
       compilation.emitAsset(
         outputPath,
         new sources.RawSource(content, false)
       );
-      
+
       manifest[namespace] = {
         path: `${this.options.publicPath}${locale}/${hashedFilename}`,
         hash: hash,
         size: content.length,
       };
-      
+
       console.log(`[${pluginName}] Processed ${locale}/${namespace} -> ${hashedFilename}`);
     }
-    
+
     return manifest;
   }
 
   private async generateManifestModules(compilation: Compilation) {
     for (const [locale, manifest] of this.translationManifests.entries()) {
       const moduleContent = this.createManifestModule(manifest);
+      // eslint-disable-next-line sonarjs/hashing
       const moduleHash = crypto
         .createHash('md5')
         .update(moduleContent)
         .digest('hex')
-        .substring(0, this.options.hashLength);
-      
+        .slice(0, Math.max(0, this.options.hashLength));
+
       const moduleName = `i18n-manifest-${locale}.${moduleHash}.js`;
-      
+
       compilation.emitAsset(
         moduleName,
         new sources.RawSource(moduleContent, false)
       );
-      
+
       this.manifestModules.set(locale, {
         name: moduleName,
         hash: moduleHash,
       });
-      
+
       console.log(`[${pluginName}] Generated manifest module: ${moduleName}`);
     }
   }
@@ -217,12 +219,12 @@ export default manifest;
   private async generateMasterManifest(compilation: Compilation) {
     const imports: string[] = [];
     const mappings: string[] = [];
-    
+
     for (const [locale, module] of this.manifestModules.entries()) {
       imports.push(`import manifest_${locale} from './${module.name}';`);
       mappings.push(`  '${locale}': () => import('./${module.name}')`);
     }
-    
+
     const masterContent = `// Auto-generated master translation manifest
 // Static imports for immediate availability
 ${imports.join('\n')}
@@ -243,7 +245,7 @@ export const loadLocaleManifest = async (locale) => {
     console.warn(\`Locale "\${locale}" not found in translation manifests\`);
     return null;
   }
-  
+
   try {
     const module = await loader();
     return module.default || module.manifest;
@@ -264,45 +266,46 @@ export const getSupportedLocales = () => {
 export const preloadLocales = async (locales = ['en']) => {
   const promises = locales.map(locale => loadLocaleManifest(locale));
   const results = await Promise.allSettled(promises);
-  
+
   const loaded: Record<string, unknown | null> = {};
   results.forEach((result, index) => {
     if (result.status === 'fulfilled') {
       loaded[locales[index]] = result.value;
     }
   });
-  
+
   return loaded;
 };
 
 // Initialize with detected locale
 export const initializeI18n = async () => {
-  const detectedLocale = (typeof navigator !== 'undefined' && typeof navigator.language === 'string' && navigator.language) 
-    ? navigator.language.split('-')[0] 
+  const detectedLocale = (typeof navigator !== 'undefined' && typeof navigator.language === 'string' && navigator.language)
+    ? navigator.language.split('-')[0]
     : 'en';
-  
+
   const supportedLocales = getSupportedLocales();
   const locale = supportedLocales.includes(detectedLocale) ? detectedLocale : 'en';
-  
+
   return loadLocaleManifest(locale);
 };
 
 export default translationManifests;
 `;
 
+    // eslint-disable-next-line sonarjs/hashing
     const masterHash = crypto
       .createHash('md5')
       .update(masterContent)
       .digest('hex')
-      .substring(0, this.options.hashLength);
-    
+      .slice(0, Math.max(0, this.options.hashLength));
+
     const masterName = `i18n-master-manifest.${masterHash}.js`;
-    
+
     compilation.emitAsset(
       masterName,
       new sources.RawSource(masterContent, false)
     );
-    
+
     // Store the master manifest name for later use
     compilation.hooks.afterProcessAssets.tap(pluginName, () => {
       if (!compilation.assets['i18n-master-manifest.json']) {
@@ -312,14 +315,14 @@ export default translationManifests;
           locales: Array.from(this.translationManifests.keys()),
           generated: new Date().toISOString(),
         };
-        
+
         compilation.emitAsset(
           'i18n-master-manifest.json',
           new sources.RawSource(JSON.stringify(metaInfo, null, 2), false)
         );
       }
     });
-    
+
     console.log(`[${pluginName}] Generated master manifest: ${masterName}`);
   }
 
@@ -329,15 +332,15 @@ export default translationManifests;
     if (!metaAsset) {
       return;
     }
-    
+
     const metaInfo = JSON.parse(metaAsset.source.source().toString());
-    
+
     // Find and update the build manifest if it exists
     const buildManifestAsset = compilation.getAsset('build-manifest.json');
     if (buildManifestAsset) {
       try {
         const manifest = JSON.parse(buildManifestAsset.source.source().toString());
-        
+
         // Add i18n information to the build manifest
         manifest.i18n = {
           masterManifest: metaInfo.masterManifest,
@@ -345,7 +348,7 @@ export default translationManifests;
           supportedLocales: metaInfo.locales,
           translationAssets: {},
         };
-        
+
         // Add translation file paths
         for (const [locale, localeManifest] of this.translationManifests.entries()) {
           manifest.i18n.translationAssets[locale] = {};
@@ -353,12 +356,12 @@ export default translationManifests;
             manifest.i18n.translationAssets[locale][namespace] = info.path;
           }
         }
-        
+
         compilation.updateAsset(
           'build-manifest.json',
           new sources.RawSource(JSON.stringify(manifest, null, 2), false)
         );
-        
+
         console.log(`[${pluginName}] Updated build-manifest.json with i18n information`);
       } catch (error) {
         console.error(`[${pluginName}] Failed to update build manifest:`, error);

--- a/packages/gdu/config/webpack/webpack.config.ts
+++ b/packages/gdu/config/webpack/webpack.config.ts
@@ -37,6 +37,7 @@ import { getBuildEnvs, getConfigsDirs } from '../../utils/configs';
 import { getHooks } from '../../utils/hooks';
 
 import { GuruBuildManifest } from './plugins/GuruBuildManifest';
+import { TranslationHashingPlugin } from './plugins/TranslationHashingPlugin';
 
 const { branch = 'null', commit = 'null' } = envCI();
 
@@ -239,6 +240,22 @@ export const baseOptions = ({
 						reuseExistingChunk: true,
 						enforce: true,
 					},
+					// i18n manifest modules
+					i18nManifests: {
+						chunks: 'all',
+						test: /i18n-manifest/,
+						name(module) {
+							// Keep the original name for i18n manifest files
+							const moduleFileName = module.identifier().split('/').pop();
+							if (moduleFileName && moduleFileName.includes('i18n-manifest')) {
+								return moduleFileName.replace('.js', '');
+							}
+							return 'i18n-manifests';
+						},
+						priority: 90,
+						reuseExistingChunk: true,
+						enforce: true,
+					},
 				},
 			},
 			moduleIds: 'deterministic',
@@ -438,6 +455,12 @@ export const baseOptions = ({
 						? resolve(PROJECT_ROOT, 'dist')
 						: resolve(PROJECT_ROOT, 'dist', buildEnv),
 				includeChunks: true,
+			}),
+			new TranslationHashingPlugin({
+				publicPath: guruConfig.publicPath ? `${guruConfig.publicPath}locales/` : '/locales/',
+				outputPath: 'locales/',
+				localesDir: 'public/locales',
+				hashLength: 8,
 			}),
 			new SourceMapDevToolPlugin({
 				exclude: standalone


### PR DESCRIPTION
This pull request introduces a new system for managing and optimizing translation assets in the build process. The main change is the addition of the `TranslationHashingPlugin`, which generates hashed translation files, per-locale manifest modules, and a master manifest for efficient i18n asset loading. The webpack configuration is updated to integrate this plugin and optimize chunking for i18n manifests.

**Internationalization (i18n) asset management:**

* Added `TranslationHashingPlugin` in `packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts`, which:
  * Processes translation files per locale, generates content hashes, and emits hashed translation assets.
  * Creates per-locale manifest modules and a master manifest for dynamic/static loading.
  * Updates `build-manifest.json` with i18n metadata and translation asset paths.

**Webpack configuration updates:**

* Registered `TranslationHashingPlugin` in the webpack configuration to enable translation asset processing during builds. [[1]](diffhunk://#diff-17332249c7964fab57a85fa8ccd5ed104619bf9629ba8152e0f120b236180d2eR40) [[2]](diffhunk://#diff-17332249c7964fab57a85fa8ccd5ed104619bf9629ba8152e0f120b236180d2eR459-R464)
* Added a new `i18nManifests` cache group in webpack's optimization settings to chunk i18n manifest modules separately, improving caching and load performance.