### PR TITLE
feat: add TranslationHashingPlugin for i18n support

### DIFF
--- a/.changeset/nice-states-rule.md
+++ b/.changeset/nice-states-rule.md
@@ -1,0 +1,5 @@
+---
+'gdu': patch
+---
+
+Fixes generated manifest for translations

--- a/.changeset/ready-boats-drop.md
+++ b/.changeset/ready-boats-drop.md
@@ -1,0 +1,5 @@
+---
+'gdu': minor
+---
+
+Adds support for hashing i18n translation files

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,29 @@
+# Commit staged changes. Use `/commit all` or `/commit -a` to stage all changes first and commit 
+Commit staged changes if $ARGUMENTS is empty or is not `all` case insensitive or `-a` or there are no staged changes in which case you should stage all the changes to commit.
+Commit messages should never reference claude code in message or as co-author.
+Commit messages should include meaningful and helpful commit summaries when applicable to the changes being commited.
+Commit messages must always use Australian/UK spellings.
+Commit message should follow Semantic Commit Messages standard defined bellow
+
+## Semantic Commit Messages:
+
+Format: <type>(<scope>): <subject>
+
+<scope> is optional
+
+Example
+feat: add centralised logging provider
+^--^  ^------------^
+|     |
+|     +-> Summary in present tense.
+|
++-------> Type: chore, docs, feat, fix, refactor, style, or test.
+More Examples:
+
+feat: (new feature for the user, not a new feature for build script)
+fix: (bug fix for the user, not a fix to a build script)
+docs: (changes to the documentation)
+style: (formatting, missing semi colons, etc; no production code change)
+refactor: (refactoring production code, eg. renaming a variable)
+test: (adding missing tests, refactoring tests; no production code change)
+chore: (updating grunt tasks etc; no production code change)

--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -1,4 +1,4 @@
 # Runs code linting. Use `/lint fix` or `/lint -f` to attempt fixing linting errors.
 Run this command from the monorepo root folder
-yarn relay && yarn format && yarn lint
+yarn format && yarn lint
 If $ARGUMENTS has `-f` or case insensitive `fix` you should fix linting errors if any from the previous command

--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -1,0 +1,4 @@
+# Runs code linting. Use `/lint fix` or `/lint -f` to attempt fixing linting errors.
+Run this command from the monorepo root folder
+yarn relay && yarn format && yarn lint
+If $ARGUMENTS has `-f` or case insensitive `fix` you should fix linting errors if any from the previous command

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,34 @@
+# Creates a new draft Pull Request or updates the PR body for an existing one with latest changes. Use `/pr AG-12345` to tag the Pull request with ticket name otherwise you will be asked to provide one.
+
+Check if the curent branch has an existing PR. 
+If a PR exisits then update the title and body based on the latest changes in the branch following the title and body requirements beloow and show the user a link to the PR.
+if no PR exists then create new draft Pull Request.
+
+PR title and body must always use Australian/UK spellings.
+PR title should follow Semantic Commit Messages standard defined bellow
+PR body should start with the value for $ARGUMENTS ins a seperate line. If $ARGUMENTS is empty you should provide the user for as promt to optionally opvide the value with this message `What is you JIRA ticket number for this PR?` and use the user response for the $ARGUMENTS. If the user did not provide a value for the JIRA ticket number then do not include the $ARGUMENTS line in PR bofy.
+PR body should include meaningful and helpful commit summaries when applicable to the changes in the branch and where apopropriate include tabales and mermaid chart format charts.
+
+
+## Semantic Commit Messages:
+
+Format: <type>(<scope>): <subject>
+
+<scope> is optional
+
+Example
+feat: add centralised logging provider
+^--^  ^------------^
+|     |
+|     +-> Summary in present tense.
+|
++-------> Type: chore, docs, feat, fix, refactor, style, or test.
+More Examples:
+
+feat: (new feature for the user, not a new feature for build script)
+fix: (bug fix for the user, not a fix to a build script)
+docs: (changes to the documentation)
+style: (formatting, missing semi colons, etc; no production code change)
+refactor: (refactoring production code, eg. renaming a variable)
+test: (adding missing tests, refactoring tests; no production code change)
+chore: (updating grunt tasks etc; no production code change)

--- a/.claude/commands/yarn.md
+++ b/.claude/commands/yarn.md
@@ -1,5 +1,5 @@
 # Installs dependencies and runs relay and format commands
 Run this command from the monorepo root folder
-`yarn install && yarn relay && yarn format`
+`yarn install && yarn format`
 
 If there was errors yarn install command then run `yarn manypkg fix` commans and `yarn install && yarn relay && yarn format` command again

--- a/.claude/commands/yarn.md
+++ b/.claude/commands/yarn.md
@@ -1,0 +1,5 @@
+# Installs dependencies and runs relay and format commands
+Run this command from the monorepo root folder
+`yarn install && yarn relay && yarn format`
+
+If there was errors yarn install command then run `yarn manypkg fix` commans and `yarn install && yarn relay && yarn format` command again

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,22 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(yarn relay)",
+      "Bash(yarn lint)",
+      "Bash(yarn format)",
+      "Bash(yarn install)",
+      "Bash(git commit:*)",
+      "Bash(git add:*)",
+      "Bash(gh:*)",
+      "Bash(git push:*)",
+      "Bash(yarn manypkg:*)",
+      "Bash(yarn list:*)"
+    ]
+  },
+  "enabledMcpjsonServers": [
+    "nx-mcp",
+    "Figma Dev Mode MCP",
+    "playwright",
+    "Overdrive Docs"
+  ]
+}

--- a/packages/babel-preset/readme.md
+++ b/packages/babel-preset/readme.md
@@ -25,6 +25,7 @@ module.exports = {
 
 - `@autoguru/babel-preset` is merely an alias of `@autoguru/babel-preset/web`.
 - `@autoguru/babel-preset/node` is for node based targets.
+
     - `version` (default: current) - the version of node you're targeting
     - `modules` (default: commonjs) - what module transformations to apply.
     - `debug` (default: isProduction) - a boolean indicating if you want debug
@@ -37,6 +38,7 @@ module.exports = {
   This will look for a
   [browserslist config](https://github.com/browserslist/browserslist) file up
   the tree.
+
     - `modules` (default: false) - if you require module transformations. False
       is default as we use webpack's bundling system and want naked esmodules.
     - `debug` (default: isProduction) - a boolean indicating if you want debug

--- a/packages/browserslist-config/readme.md
+++ b/packages/browserslist-config/readme.md
@@ -19,6 +19,7 @@ To keep us up to date:
 1. From the root octane directory:
     1. Run `npx browserslist@latest --update-db`
 1. From the browserlist-config directory:
+
     1. Update package.json with latest
        [browserslist](https://www.npmjs.com/package/browserslist) version
     1. Run `yarn`

--- a/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
+++ b/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
@@ -277,7 +277,7 @@ export const preloadLocales = async (locales = ['en']) => {
 
 // Initialize with detected locale
 export const initializeI18n = async () => {
-  const detectedLocale = (typeof navigator !== 'undefined' && navigator.language) 
+  const detectedLocale = (typeof navigator !== 'undefined' && typeof navigator.language === 'string' && navigator.language) 
     ? navigator.language.split('-')[0] 
     : 'en';
   

--- a/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
+++ b/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
@@ -265,7 +265,7 @@ export const preloadLocales = async (locales = ['en']) => {
   const promises = locales.map(locale => loadLocaleManifest(locale));
   const results = await Promise.allSettled(promises);
   
-  const loaded = {};
+  const loaded: Record<string, unknown | null> = {};
   results.forEach((result, index) => {
     if (result.status === 'fulfilled') {
       loaded[locales[index]] = result.value;

--- a/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
+++ b/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
@@ -267,7 +267,7 @@ export const preloadLocales = async (locales = ['en']) => {
   const promises = locales.map(locale => loadLocaleManifest(locale));
   const results = await Promise.allSettled(promises);
 
-  const loaded: Record<string, unknown | null> = {};
+  const loaded = {};
   results.forEach((result, index) => {
     if (result.status === 'fulfilled') {
       loaded[locales[index]] = result.value;

--- a/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
+++ b/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
@@ -1,0 +1,368 @@
+import crypto from 'crypto';
+import { promises as fs } from 'fs';
+import { existsSync } from 'fs';
+import path from 'path';
+import { Compiler, Compilation, sources } from 'webpack';
+
+interface TranslationInfo {
+  path: string;
+  hash: string;
+  size: number;
+}
+
+interface LocaleManifest {
+  [namespace: string]: TranslationInfo;
+}
+
+interface ManifestModule {
+  name: string;
+  hash: string;
+}
+
+interface PluginOptions {
+  publicPath?: string;
+  outputPath?: string;
+  localesDir?: string;
+  hashLength?: number;
+  excludeLocales?: string[];
+}
+
+const pluginName = 'TranslationHashingPlugin';
+
+export class TranslationHashingPlugin {
+  private options: Required<PluginOptions>;
+  private translationManifests: Map<string, LocaleManifest> = new Map();
+  private manifestModules: Map<string, ManifestModule> = new Map();
+
+  constructor(options: PluginOptions = {}) {
+    this.options = {
+      publicPath: options.publicPath || '/locales/',
+      outputPath: options.outputPath || 'locales/',
+      localesDir: options.localesDir || 'public/locales',
+      hashLength: options.hashLength || 8,
+      excludeLocales: options.excludeLocales || [],
+    };
+  }
+
+  apply(compiler: Compiler) {
+    compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
+      compilation.hooks.processAssets.tapAsync(
+        {
+          name: pluginName,
+          stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
+        },
+        async (_assets, callback) => {
+          try {
+            await this.processTranslations(compiler, compilation);
+            callback();
+          } catch (error) {
+            callback(error as Error);
+          }
+        }
+      );
+    });
+
+    // Hook into the emit phase to update the build manifest
+    compiler.hooks.emit.tapAsync(pluginName, async (compilation, callback) => {
+      try {
+        await this.updateBuildManifest(compilation);
+        callback();
+      } catch (error) {
+        callback(error as Error);
+      }
+    });
+  }
+
+  private async processTranslations(compiler: Compiler, compilation: Compilation) {
+    const localesPath = path.join(compiler.context, this.options.localesDir);
+    
+    if (!existsSync(localesPath)) {
+      console.log(`[${pluginName}] No locales directory found at ${localesPath}`);
+      return;
+    }
+
+    console.log(`[${pluginName}] Processing translations from ${localesPath}`);
+    
+    // Get all locale directories
+    const locales = await fs.readdir(localesPath);
+    
+    for (const locale of locales) {
+      if (this.options.excludeLocales.includes(locale)) {
+        continue;
+      }
+      
+      const localePath = path.join(localesPath, locale);
+      const stat = await fs.stat(localePath);
+      
+      if (stat.isDirectory()) {
+        const manifest = await this.processLocale(localePath, locale, compilation);
+        this.translationManifests.set(locale, manifest);
+      }
+    }
+
+    // Generate per-locale manifest modules
+    await this.generateManifestModules(compilation);
+    
+    // Generate master manifest module
+    await this.generateMasterManifest(compilation);
+  }
+
+  private async processLocale(
+    localePath: string,
+    locale: string,
+    compilation: Compilation
+  ): Promise<LocaleManifest> {
+    const manifest: LocaleManifest = {};
+    const files = await fs.readdir(localePath);
+    
+    for (const file of files) {
+      if (!file.endsWith('.json')) {
+        continue;
+      }
+      
+      const filePath = path.join(localePath, file);
+      const content = await fs.readFile(filePath, 'utf-8');
+      
+      // Generate content hash
+      const hash = crypto
+        .createHash('md5')
+        .update(content)
+        .digest('hex')
+        .substring(0, this.options.hashLength);
+      
+      const namespace = file.replace('.json', '');
+      const hashedFilename = `${namespace}.${hash}.json`;
+      const outputPath = path.join(this.options.outputPath, locale, hashedFilename);
+      
+      // Add to compilation assets
+      compilation.emitAsset(
+        outputPath,
+        new sources.RawSource(content, false)
+      );
+      
+      manifest[namespace] = {
+        path: `${this.options.publicPath}${locale}/${hashedFilename}`,
+        hash: hash,
+        size: content.length,
+      };
+      
+      console.log(`[${pluginName}] Processed ${locale}/${namespace} -> ${hashedFilename}`);
+    }
+    
+    return manifest;
+  }
+
+  private async generateManifestModules(compilation: Compilation) {
+    for (const [locale, manifest] of this.translationManifests.entries()) {
+      const moduleContent = this.createManifestModule(manifest);
+      const moduleHash = crypto
+        .createHash('md5')
+        .update(moduleContent)
+        .digest('hex')
+        .substring(0, this.options.hashLength);
+      
+      const moduleName = `i18n-manifest-${locale}.${moduleHash}.js`;
+      
+      compilation.emitAsset(
+        moduleName,
+        new sources.RawSource(moduleContent, false)
+      );
+      
+      this.manifestModules.set(locale, {
+        name: moduleName,
+        hash: moduleHash,
+      });
+      
+      console.log(`[${pluginName}] Generated manifest module: ${moduleName}`);
+    }
+  }
+
+  private createManifestModule(manifest: LocaleManifest): string {
+    return `// Auto-generated translation manifest
+export const manifest = ${JSON.stringify(manifest, null, 2)};
+
+export const getTranslationPath = (namespace) => {
+  const translation = manifest[namespace];
+  if (!translation) {
+    console.warn(\`Translation namespace "\${namespace}" not found in manifest\`);
+    return null;
+  }
+  return translation.path;
+};
+
+export const getTranslationHash = (namespace) => {
+  return manifest[namespace]?.hash;
+};
+
+export const getTranslationSize = (namespace) => {
+  return manifest[namespace]?.size;
+};
+
+export const getAllNamespaces = () => {
+  return Object.keys(manifest);
+};
+
+export const getManifestInfo = () => {
+  return {
+    namespaces: Object.keys(manifest),
+    totalSize: Object.values(manifest).reduce((sum, info) => sum + info.size, 0),
+    translations: manifest,
+  };
+};
+
+export default manifest;
+`;
+  }
+
+  private async generateMasterManifest(compilation: Compilation) {
+    const imports: string[] = [];
+    const mappings: string[] = [];
+    
+    for (const [locale, module] of this.manifestModules.entries()) {
+      imports.push(`import manifest_${locale} from './${module.name}';`);
+      mappings.push(`  '${locale}': () => import('./${module.name}')`);
+    }
+    
+    const masterContent = `// Auto-generated master translation manifest
+// Static imports for immediate availability
+${imports.join('\n')}
+
+// Dynamic imports for lazy loading
+export const translationManifests = {
+${mappings.join(',\n')}
+};
+
+// Static manifest access for SSR/preloading
+export const staticManifests = {
+${Array.from(this.manifestModules.keys()).map(locale => `  '${locale}': manifest_${locale}`).join(',\n')}
+};
+
+export const loadLocaleManifest = async (locale) => {
+  const loader = translationManifests[locale];
+  if (!loader) {
+    console.warn(\`Locale "\${locale}" not found in translation manifests\`);
+    return null;
+  }
+  
+  try {
+    const module = await loader();
+    return module.default || module.manifest;
+  } catch (error) {
+    console.error(\`Failed to load manifest for locale "\${locale}":\`, error);
+    return null;
+  }
+};
+
+export const getStaticManifest = (locale) => {
+  return staticManifests[locale] || null;
+};
+
+export const getSupportedLocales = () => {
+  return Object.keys(translationManifests);
+};
+
+export const preloadLocales = async (locales = ['en']) => {
+  const promises = locales.map(locale => loadLocaleManifest(locale));
+  const results = await Promise.allSettled(promises);
+  
+  const loaded = {};
+  results.forEach((result, index) => {
+    if (result.status === 'fulfilled') {
+      loaded[locales[index]] = result.value;
+    }
+  });
+  
+  return loaded;
+};
+
+// Initialize with detected locale
+export const initializeI18n = async () => {
+  const detectedLocale = (typeof navigator !== 'undefined' && navigator.language) 
+    ? navigator.language.split('-')[0] 
+    : 'en';
+  
+  const supportedLocales = getSupportedLocales();
+  const locale = supportedLocales.includes(detectedLocale) ? detectedLocale : 'en';
+  
+  return loadLocaleManifest(locale);
+};
+
+export default translationManifests;
+`;
+
+    const masterHash = crypto
+      .createHash('md5')
+      .update(masterContent)
+      .digest('hex')
+      .substring(0, this.options.hashLength);
+    
+    const masterName = `i18n-master-manifest.${masterHash}.js`;
+    
+    compilation.emitAsset(
+      masterName,
+      new sources.RawSource(masterContent, false)
+    );
+    
+    // Store the master manifest name for later use
+    compilation.hooks.afterProcessAssets.tap(pluginName, () => {
+      if (!compilation.assets['i18n-master-manifest.json']) {
+        const metaInfo = {
+          masterManifest: masterName,
+          manifestModules: Object.fromEntries(this.manifestModules),
+          locales: Array.from(this.translationManifests.keys()),
+          generated: new Date().toISOString(),
+        };
+        
+        compilation.emitAsset(
+          'i18n-master-manifest.json',
+          new sources.RawSource(JSON.stringify(metaInfo, null, 2), false)
+        );
+      }
+    });
+    
+    console.log(`[${pluginName}] Generated master manifest: ${masterName}`);
+  }
+
+  private async updateBuildManifest(compilation: Compilation) {
+    // Find the i18n master manifest metadata
+    const metaAsset = compilation.getAsset('i18n-master-manifest.json');
+    if (!metaAsset) {
+      return;
+    }
+    
+    const metaInfo = JSON.parse(metaAsset.source.source().toString());
+    
+    // Find and update the build manifest if it exists
+    const buildManifestAsset = compilation.getAsset('build-manifest.json');
+    if (buildManifestAsset) {
+      try {
+        const manifest = JSON.parse(buildManifestAsset.source.source().toString());
+        
+        // Add i18n information to the build manifest
+        manifest.i18n = {
+          masterManifest: metaInfo.masterManifest,
+          manifestModules: metaInfo.manifestModules,
+          supportedLocales: metaInfo.locales,
+          translationAssets: {},
+        };
+        
+        // Add translation file paths
+        for (const [locale, localeManifest] of this.translationManifests.entries()) {
+          manifest.i18n.translationAssets[locale] = {};
+          for (const [namespace, info] of Object.entries(localeManifest)) {
+            manifest.i18n.translationAssets[locale][namespace] = info.path;
+          }
+        }
+        
+        compilation.updateAsset(
+          'build-manifest.json',
+          new sources.RawSource(JSON.stringify(manifest, null, 2), false)
+        );
+        
+        console.log(`[${pluginName}] Updated build-manifest.json with i18n information`);
+      } catch (error) {
+        console.error(`[${pluginName}] Failed to update build manifest:`, error);
+      }
+    }
+  }
+}

--- a/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
+++ b/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
-import { promises as fs } from 'fs';
-import { existsSync } from 'fs';
+import { promises as fs , existsSync } from 'fs';
 import path from 'path';
+
 import { Compiler, Compilation, sources } from 'webpack';
 
 interface TranslationInfo {
@@ -75,25 +75,25 @@ export class TranslationHashingPlugin {
 
   private async processTranslations(compiler: Compiler, compilation: Compilation) {
     const localesPath = path.join(compiler.context, this.options.localesDir);
-    
+
     if (!existsSync(localesPath)) {
       console.log(`[${pluginName}] No locales directory found at ${localesPath}`);
       return;
     }
 
     console.log(`[${pluginName}] Processing translations from ${localesPath}`);
-    
+
     // Get all locale directories
     const locales = await fs.readdir(localesPath);
-    
+
     for (const locale of locales) {
       if (this.options.excludeLocales.includes(locale)) {
         continue;
       }
-      
+
       const localePath = path.join(localesPath, locale);
       const stat = await fs.stat(localePath);
-      
+
       if (stat.isDirectory()) {
         const manifest = await this.processLocale(localePath, locale, compilation);
         this.translationManifests.set(locale, manifest);
@@ -102,7 +102,7 @@ export class TranslationHashingPlugin {
 
     // Generate per-locale manifest modules
     await this.generateManifestModules(compilation);
-    
+
     // Generate master manifest module
     await this.generateMasterManifest(compilation);
   }
@@ -114,65 +114,67 @@ export class TranslationHashingPlugin {
   ): Promise<LocaleManifest> {
     const manifest: LocaleManifest = {};
     const files = await fs.readdir(localePath);
-    
+
     for (const file of files) {
       if (!file.endsWith('.json')) {
         continue;
       }
-      
+
       const filePath = path.join(localePath, file);
-      const content = await fs.readFile(filePath, 'utf-8');
-      
+      const content = await fs.readFile(filePath, 'utf8');
+
       // Generate content hash
+      // eslint-disable-next-line sonarjs/hashing
       const hash = crypto
         .createHash('md5')
         .update(content)
         .digest('hex')
-        .substring(0, this.options.hashLength);
-      
+        .slice(0, Math.max(0, this.options.hashLength));
+
       const namespace = file.replace('.json', '');
       const hashedFilename = `${namespace}.${hash}.json`;
       const outputPath = path.join(this.options.outputPath, locale, hashedFilename);
-      
+
       // Add to compilation assets
       compilation.emitAsset(
         outputPath,
         new sources.RawSource(content, false)
       );
-      
+
       manifest[namespace] = {
         path: `${this.options.publicPath}${locale}/${hashedFilename}`,
         hash: hash,
         size: content.length,
       };
-      
+
       console.log(`[${pluginName}] Processed ${locale}/${namespace} -> ${hashedFilename}`);
     }
-    
+
     return manifest;
   }
 
   private async generateManifestModules(compilation: Compilation) {
     for (const [locale, manifest] of this.translationManifests.entries()) {
       const moduleContent = this.createManifestModule(manifest);
+      // eslint-disable-next-line sonarjs/hashing
       const moduleHash = crypto
         .createHash('md5')
         .update(moduleContent)
         .digest('hex')
-        .substring(0, this.options.hashLength);
-      
+        .slice(0, Math.max(0, this.options.hashLength));
+
       const moduleName = `i18n-manifest-${locale}.${moduleHash}.js`;
-      
+
       compilation.emitAsset(
         moduleName,
         new sources.RawSource(moduleContent, false)
       );
-      
+
       this.manifestModules.set(locale, {
         name: moduleName,
         hash: moduleHash,
       });
-      
+
       console.log(`[${pluginName}] Generated manifest module: ${moduleName}`);
     }
   }
@@ -217,12 +219,12 @@ export default manifest;
   private async generateMasterManifest(compilation: Compilation) {
     const imports: string[] = [];
     const mappings: string[] = [];
-    
+
     for (const [locale, module] of this.manifestModules.entries()) {
       imports.push(`import manifest_${locale} from './${module.name}';`);
       mappings.push(`  '${locale}': () => import('./${module.name}')`);
     }
-    
+
     const masterContent = `// Auto-generated master translation manifest
 // Static imports for immediate availability
 ${imports.join('\n')}
@@ -243,7 +245,7 @@ export const loadLocaleManifest = async (locale) => {
     console.warn(\`Locale "\${locale}" not found in translation manifests\`);
     return null;
   }
-  
+
   try {
     const module = await loader();
     return module.default || module.manifest;
@@ -264,45 +266,46 @@ export const getSupportedLocales = () => {
 export const preloadLocales = async (locales = ['en']) => {
   const promises = locales.map(locale => loadLocaleManifest(locale));
   const results = await Promise.allSettled(promises);
-  
+
   const loaded: Record<string, unknown | null> = {};
   results.forEach((result, index) => {
     if (result.status === 'fulfilled') {
       loaded[locales[index]] = result.value;
     }
   });
-  
+
   return loaded;
 };
 
 // Initialize with detected locale
 export const initializeI18n = async () => {
-  const detectedLocale = (typeof navigator !== 'undefined' && typeof navigator.language === 'string' && navigator.language) 
-    ? navigator.language.split('-')[0] 
+  const detectedLocale = (typeof navigator !== 'undefined' && typeof navigator.language === 'string' && navigator.language)
+    ? navigator.language.split('-')[0]
     : 'en';
-  
+
   const supportedLocales = getSupportedLocales();
   const locale = supportedLocales.includes(detectedLocale) ? detectedLocale : 'en';
-  
+
   return loadLocaleManifest(locale);
 };
 
 export default translationManifests;
 `;
 
+    // eslint-disable-next-line sonarjs/hashing
     const masterHash = crypto
       .createHash('md5')
       .update(masterContent)
       .digest('hex')
-      .substring(0, this.options.hashLength);
-    
+      .slice(0, Math.max(0, this.options.hashLength));
+
     const masterName = `i18n-master-manifest.${masterHash}.js`;
-    
+
     compilation.emitAsset(
       masterName,
       new sources.RawSource(masterContent, false)
     );
-    
+
     // Store the master manifest name for later use
     compilation.hooks.afterProcessAssets.tap(pluginName, () => {
       if (!compilation.assets['i18n-master-manifest.json']) {
@@ -312,14 +315,14 @@ export default translationManifests;
           locales: Array.from(this.translationManifests.keys()),
           generated: new Date().toISOString(),
         };
-        
+
         compilation.emitAsset(
           'i18n-master-manifest.json',
           new sources.RawSource(JSON.stringify(metaInfo, null, 2), false)
         );
       }
     });
-    
+
     console.log(`[${pluginName}] Generated master manifest: ${masterName}`);
   }
 
@@ -329,15 +332,15 @@ export default translationManifests;
     if (!metaAsset) {
       return;
     }
-    
+
     const metaInfo = JSON.parse(metaAsset.source.source().toString());
-    
+
     // Find and update the build manifest if it exists
     const buildManifestAsset = compilation.getAsset('build-manifest.json');
     if (buildManifestAsset) {
       try {
         const manifest = JSON.parse(buildManifestAsset.source.source().toString());
-        
+
         // Add i18n information to the build manifest
         manifest.i18n = {
           masterManifest: metaInfo.masterManifest,
@@ -345,7 +348,7 @@ export default translationManifests;
           supportedLocales: metaInfo.locales,
           translationAssets: {},
         };
-        
+
         // Add translation file paths
         for (const [locale, localeManifest] of this.translationManifests.entries()) {
           manifest.i18n.translationAssets[locale] = {};
@@ -353,12 +356,12 @@ export default translationManifests;
             manifest.i18n.translationAssets[locale][namespace] = info.path;
           }
         }
-        
+
         compilation.updateAsset(
           'build-manifest.json',
           new sources.RawSource(JSON.stringify(manifest, null, 2), false)
         );
-        
+
         console.log(`[${pluginName}] Updated build-manifest.json with i18n information`);
       } catch (error) {
         console.error(`[${pluginName}] Failed to update build manifest:`, error);

--- a/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
+++ b/packages/gdu/config/webpack/plugins/TranslationHashingPlugin.ts
@@ -1,186 +1,211 @@
 import crypto from 'crypto';
-import { promises as fs , existsSync } from 'fs';
+import { promises as fs, existsSync } from 'fs';
 import path from 'path';
 
 import { Compiler, Compilation, sources } from 'webpack';
 
 interface TranslationInfo {
-  path: string;
-  hash: string;
-  size: number;
+	path: string;
+	hash: string;
+	size: number;
 }
 
 interface LocaleManifest {
-  [namespace: string]: TranslationInfo;
+	[namespace: string]: TranslationInfo;
 }
 
 interface ManifestModule {
-  name: string;
-  hash: string;
+	name: string;
+	hash: string;
 }
 
 interface PluginOptions {
-  publicPath?: string;
-  outputPath?: string;
-  localesDir?: string;
-  hashLength?: number;
-  excludeLocales?: string[];
+	publicPath?: string;
+	outputPath?: string;
+	localesDir?: string;
+	hashLength?: number;
+	excludeLocales?: string[];
 }
 
 const pluginName = 'TranslationHashingPlugin';
 
 export class TranslationHashingPlugin {
-  private options: Required<PluginOptions>;
-  private translationManifests: Map<string, LocaleManifest> = new Map();
-  private manifestModules: Map<string, ManifestModule> = new Map();
+	private options: Required<PluginOptions>;
+	private translationManifests: Map<string, LocaleManifest> = new Map();
+	private manifestModules: Map<string, ManifestModule> = new Map();
 
-  constructor(options: PluginOptions = {}) {
-    this.options = {
-      publicPath: options.publicPath || '/locales/',
-      outputPath: options.outputPath || 'locales/',
-      localesDir: options.localesDir || 'public/locales',
-      hashLength: options.hashLength || 8,
-      excludeLocales: options.excludeLocales || [],
-    };
-  }
+	constructor(options: PluginOptions = {}) {
+		this.options = {
+			publicPath: options.publicPath || '/locales/',
+			outputPath: options.outputPath || 'locales/',
+			localesDir: options.localesDir || 'public/locales',
+			hashLength: options.hashLength || 8,
+			excludeLocales: options.excludeLocales || [],
+		};
+	}
 
-  apply(compiler: Compiler) {
-    compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
-      compilation.hooks.processAssets.tapAsync(
-        {
-          name: pluginName,
-          stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
-        },
-        async (_assets, callback) => {
-          try {
-            await this.processTranslations(compiler, compilation);
-            callback();
-          } catch (error) {
-            callback(error as Error);
-          }
-        }
-      );
-    });
+	apply(compiler: Compiler) {
+		compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
+			compilation.hooks.processAssets.tapAsync(
+				{
+					name: pluginName,
+					stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
+				},
+				async (_assets, callback) => {
+					try {
+						await this.processTranslations(compiler, compilation);
+						callback();
+					} catch (error) {
+						callback(error as Error);
+					}
+				},
+			);
+		});
 
-    // Hook into the emit phase to update the build manifest
-    compiler.hooks.emit.tapAsync(pluginName, async (compilation, callback) => {
-      try {
-        await this.updateBuildManifest(compilation);
-        callback();
-      } catch (error) {
-        callback(error as Error);
-      }
-    });
-  }
+		// Hook into the emit phase to update the build manifest
+		compiler.hooks.emit.tapAsync(
+			pluginName,
+			async (compilation, callback) => {
+				try {
+					await this.updateBuildManifest(compilation);
+					callback();
+				} catch (error) {
+					callback(error as Error);
+				}
+			},
+		);
+	}
 
-  private async processTranslations(compiler: Compiler, compilation: Compilation) {
-    const localesPath = path.join(compiler.context, this.options.localesDir);
+	private async processTranslations(
+		compiler: Compiler,
+		compilation: Compilation,
+	) {
+		const localesPath = path.join(
+			compiler.context,
+			this.options.localesDir,
+		);
 
-    if (!existsSync(localesPath)) {
-      console.log(`[${pluginName}] No locales directory found at ${localesPath}`);
-      return;
-    }
+		if (!existsSync(localesPath)) {
+			console.log(
+				`[${pluginName}] No locales directory found at ${localesPath}`,
+			);
+			return;
+		}
 
-    console.log(`[${pluginName}] Processing translations from ${localesPath}`);
+		console.log(
+			`[${pluginName}] Processing translations from ${localesPath}`,
+		);
 
-    // Get all locale directories
-    const locales = await fs.readdir(localesPath);
+		// Get all locale directories
+		const locales = await fs.readdir(localesPath);
 
-    for (const locale of locales) {
-      if (this.options.excludeLocales.includes(locale)) {
-        continue;
-      }
+		for (const locale of locales) {
+			if (this.options.excludeLocales.includes(locale)) {
+				continue;
+			}
 
-      const localePath = path.join(localesPath, locale);
-      const stat = await fs.stat(localePath);
+			const localePath = path.join(localesPath, locale);
+			const stat = await fs.stat(localePath);
 
-      if (stat.isDirectory()) {
-        const manifest = await this.processLocale(localePath, locale, compilation);
-        this.translationManifests.set(locale, manifest);
-      }
-    }
+			if (stat.isDirectory()) {
+				const manifest = await this.processLocale(
+					localePath,
+					locale,
+					compilation,
+				);
+				this.translationManifests.set(locale, manifest);
+			}
+		}
 
-    // Generate per-locale manifest modules
-    await this.generateManifestModules(compilation);
+		// Generate per-locale manifest modules
+		await this.generateManifestModules(compilation);
 
-    // Generate master manifest module
-    await this.generateMasterManifest(compilation);
-  }
+		// Generate master manifest module
+		await this.generateMasterManifest(compilation);
+	}
 
-  private async processLocale(
-    localePath: string,
-    locale: string,
-    compilation: Compilation
-  ): Promise<LocaleManifest> {
-    const manifest: LocaleManifest = {};
-    const files = await fs.readdir(localePath);
+	private async processLocale(
+		localePath: string,
+		locale: string,
+		compilation: Compilation,
+	): Promise<LocaleManifest> {
+		const manifest: LocaleManifest = {};
+		const files = await fs.readdir(localePath);
 
-    for (const file of files) {
-      if (!file.endsWith('.json')) {
-        continue;
-      }
+		for (const file of files) {
+			if (!file.endsWith('.json')) {
+				continue;
+			}
 
-      const filePath = path.join(localePath, file);
-      const content = await fs.readFile(filePath, 'utf8');
+			const filePath = path.join(localePath, file);
+			const content = await fs.readFile(filePath, 'utf8');
 
-      // Generate content hash
-      // eslint-disable-next-line sonarjs/hashing
-      const hash = crypto
-        .createHash('md5')
-        .update(content)
-        .digest('hex')
-        .slice(0, Math.max(0, this.options.hashLength));
+			// Generate content hash
+			// eslint-disable-next-line sonarjs/hashing
+			const hash = crypto
+				.createHash('md5')
+				.update(content)
+				.digest('hex')
+				.slice(0, Math.max(0, this.options.hashLength));
 
-      const namespace = file.replace('.json', '');
-      const hashedFilename = `${namespace}.${hash}.json`;
-      const outputPath = path.join(this.options.outputPath, locale, hashedFilename);
+			const namespace = file.replace('.json', '');
+			const hashedFilename = `${namespace}.${hash}.json`;
+			const outputPath = path.join(
+				this.options.outputPath,
+				locale,
+				hashedFilename,
+			);
 
-      // Add to compilation assets
-      compilation.emitAsset(
-        outputPath,
-        new sources.RawSource(content, false)
-      );
+			// Add to compilation assets
+			compilation.emitAsset(
+				outputPath,
+				new sources.RawSource(content, false),
+			);
 
-      manifest[namespace] = {
-        path: `${this.options.publicPath}${locale}/${hashedFilename}`,
-        hash: hash,
-        size: content.length,
-      };
+			manifest[namespace] = {
+				path: `${this.options.publicPath}${locale}/${hashedFilename}`,
+				hash: hash,
+				size: content.length,
+			};
 
-      console.log(`[${pluginName}] Processed ${locale}/${namespace} -> ${hashedFilename}`);
-    }
+			console.log(
+				`[${pluginName}] Processed ${locale}/${namespace} -> ${hashedFilename}`,
+			);
+		}
 
-    return manifest;
-  }
+		return manifest;
+	}
 
-  private async generateManifestModules(compilation: Compilation) {
-    for (const [locale, manifest] of this.translationManifests.entries()) {
-      const moduleContent = this.createManifestModule(manifest);
-      // eslint-disable-next-line sonarjs/hashing
-      const moduleHash = crypto
-        .createHash('md5')
-        .update(moduleContent)
-        .digest('hex')
-        .slice(0, Math.max(0, this.options.hashLength));
+	private async generateManifestModules(compilation: Compilation) {
+		for (const [locale, manifest] of this.translationManifests.entries()) {
+			const moduleContent = this.createManifestModule(manifest);
+			// eslint-disable-next-line sonarjs/hashing
+			const moduleHash = crypto
+				.createHash('md5')
+				.update(moduleContent)
+				.digest('hex')
+				.slice(0, Math.max(0, this.options.hashLength));
 
-      const moduleName = `i18n-manifest-${locale}.${moduleHash}.js`;
+			const moduleName = `i18n-manifest-${locale}.${moduleHash}.js`;
 
-      compilation.emitAsset(
-        moduleName,
-        new sources.RawSource(moduleContent, false)
-      );
+			compilation.emitAsset(
+				moduleName,
+				new sources.RawSource(moduleContent, false),
+			);
 
-      this.manifestModules.set(locale, {
-        name: moduleName,
-        hash: moduleHash,
-      });
+			this.manifestModules.set(locale, {
+				name: moduleName,
+				hash: moduleHash,
+			});
 
-      console.log(`[${pluginName}] Generated manifest module: ${moduleName}`);
-    }
-  }
+			console.log(
+				`[${pluginName}] Generated manifest module: ${moduleName}`,
+			);
+		}
+	}
 
-  private createManifestModule(manifest: LocaleManifest): string {
-    return `// Auto-generated translation manifest
+	private createManifestModule(manifest: LocaleManifest): string {
+		return `// Auto-generated translation manifest
 export const manifest = ${JSON.stringify(manifest, null, 2)};
 
 export const getTranslationPath = (namespace) => {
@@ -214,18 +239,18 @@ export const getManifestInfo = () => {
 
 export default manifest;
 `;
-  }
+	}
 
-  private async generateMasterManifest(compilation: Compilation) {
-    const imports: string[] = [];
-    const mappings: string[] = [];
+	private async generateMasterManifest(compilation: Compilation) {
+		const imports: string[] = [];
+		const mappings: string[] = [];
 
-    for (const [locale, module] of this.manifestModules.entries()) {
-      imports.push(`import manifest_${locale} from './${module.name}';`);
-      mappings.push(`  '${locale}': () => import('./${module.name}')`);
-    }
+		for (const [locale, module] of this.manifestModules.entries()) {
+			imports.push(`import manifest_${locale} from './${module.name}';`);
+			mappings.push(`  '${locale}': () => import('./${module.name}')`);
+		}
 
-    const masterContent = `// Auto-generated master translation manifest
+		const masterContent = `// Auto-generated master translation manifest
 // Static imports for immediate availability
 ${imports.join('\n')}
 
@@ -236,7 +261,9 @@ ${mappings.join(',\n')}
 
 // Static manifest access for SSR/preloading
 export const staticManifests = {
-${Array.from(this.manifestModules.keys()).map(locale => `  '${locale}': manifest_${locale}`).join(',\n')}
+${Array.from(this.manifestModules.keys())
+	.map((locale) => `  '${locale}': manifest_${locale}`)
+	.join(',\n')}
 };
 
 export const loadLocaleManifest = async (locale) => {
@@ -292,80 +319,99 @@ export const initializeI18n = async () => {
 export default translationManifests;
 `;
 
-    // eslint-disable-next-line sonarjs/hashing
-    const masterHash = crypto
-      .createHash('md5')
-      .update(masterContent)
-      .digest('hex')
-      .slice(0, Math.max(0, this.options.hashLength));
+		// eslint-disable-next-line sonarjs/hashing
+		const masterHash = crypto
+			.createHash('md5')
+			.update(masterContent)
+			.digest('hex')
+			.slice(0, Math.max(0, this.options.hashLength));
 
-    const masterName = `i18n-master-manifest.${masterHash}.js`;
+		const masterName = `i18n-master-manifest.${masterHash}.js`;
 
-    compilation.emitAsset(
-      masterName,
-      new sources.RawSource(masterContent, false)
-    );
+		compilation.emitAsset(
+			masterName,
+			new sources.RawSource(masterContent, false),
+		);
 
-    // Store the master manifest name for later use
-    compilation.hooks.afterProcessAssets.tap(pluginName, () => {
-      if (!compilation.assets['i18n-master-manifest.json']) {
-        const metaInfo = {
-          masterManifest: masterName,
-          manifestModules: Object.fromEntries(this.manifestModules),
-          locales: Array.from(this.translationManifests.keys()),
-          generated: new Date().toISOString(),
-        };
+		// Store the master manifest name for later use
+		compilation.hooks.afterProcessAssets.tap(pluginName, () => {
+			if (!compilation.assets['i18n-master-manifest.json']) {
+				const metaInfo = {
+					masterManifest: masterName,
+					manifestModules: Object.fromEntries(this.manifestModules),
+					locales: Array.from(this.translationManifests.keys()),
+					generated: new Date().toISOString(),
+				};
 
-        compilation.emitAsset(
-          'i18n-master-manifest.json',
-          new sources.RawSource(JSON.stringify(metaInfo, null, 2), false)
-        );
-      }
-    });
+				compilation.emitAsset(
+					'i18n-master-manifest.json',
+					new sources.RawSource(
+						JSON.stringify(metaInfo, null, 2),
+						false,
+					),
+				);
+			}
+		});
 
-    console.log(`[${pluginName}] Generated master manifest: ${masterName}`);
-  }
+		console.log(`[${pluginName}] Generated master manifest: ${masterName}`);
+	}
 
-  private async updateBuildManifest(compilation: Compilation) {
-    // Find the i18n master manifest metadata
-    const metaAsset = compilation.getAsset('i18n-master-manifest.json');
-    if (!metaAsset) {
-      return;
-    }
+	private async updateBuildManifest(compilation: Compilation) {
+		// Find the i18n master manifest metadata
+		const metaAsset = compilation.getAsset('i18n-master-manifest.json');
+		if (!metaAsset) {
+			return;
+		}
 
-    const metaInfo = JSON.parse(metaAsset.source.source().toString());
+		const metaInfo = JSON.parse(metaAsset.source.source().toString());
 
-    // Find and update the build manifest if it exists
-    const buildManifestAsset = compilation.getAsset('build-manifest.json');
-    if (buildManifestAsset) {
-      try {
-        const manifest = JSON.parse(buildManifestAsset.source.source().toString());
+		// Find and update the build manifest if it exists
+		const buildManifestAsset = compilation.getAsset('build-manifest.json');
+		if (buildManifestAsset) {
+			try {
+				const manifest = JSON.parse(
+					buildManifestAsset.source.source().toString(),
+				);
 
-        // Add i18n information to the build manifest
-        manifest.i18n = {
-          masterManifest: metaInfo.masterManifest,
-          manifestModules: metaInfo.manifestModules,
-          supportedLocales: metaInfo.locales,
-          translationAssets: {},
-        };
+				// Add i18n information to the build manifest
+				manifest.i18n = {
+					masterManifest: metaInfo.masterManifest,
+					manifestModules: metaInfo.manifestModules,
+					supportedLocales: metaInfo.locales,
+					translationAssets: {},
+				};
 
-        // Add translation file paths
-        for (const [locale, localeManifest] of this.translationManifests.entries()) {
-          manifest.i18n.translationAssets[locale] = {};
-          for (const [namespace, info] of Object.entries(localeManifest)) {
-            manifest.i18n.translationAssets[locale][namespace] = info.path;
-          }
-        }
+				// Add translation file paths
+				for (const [
+					locale,
+					localeManifest,
+				] of this.translationManifests.entries()) {
+					manifest.i18n.translationAssets[locale] = {};
+					for (const [namespace, info] of Object.entries(
+						localeManifest,
+					)) {
+						manifest.i18n.translationAssets[locale][namespace] =
+							info.path;
+					}
+				}
 
-        compilation.updateAsset(
-          'build-manifest.json',
-          new sources.RawSource(JSON.stringify(manifest, null, 2), false)
-        );
+				compilation.updateAsset(
+					'build-manifest.json',
+					new sources.RawSource(
+						JSON.stringify(manifest, null, 2),
+						false,
+					),
+				);
 
-        console.log(`[${pluginName}] Updated build-manifest.json with i18n information`);
-      } catch (error) {
-        console.error(`[${pluginName}] Failed to update build manifest:`, error);
-      }
-    }
-  }
+				console.log(
+					`[${pluginName}] Updated build-manifest.json with i18n information`,
+				);
+			} catch (error) {
+				console.error(
+					`[${pluginName}] Failed to update build manifest:`,
+					error,
+				);
+			}
+		}
+	}
 }

--- a/packages/gdu/config/webpack/webpack.config.ts
+++ b/packages/gdu/config/webpack/webpack.config.ts
@@ -37,6 +37,7 @@ import { getBuildEnvs, getConfigsDirs } from '../../utils/configs';
 import { getHooks } from '../../utils/hooks';
 
 import { GuruBuildManifest } from './plugins/GuruBuildManifest';
+import { TranslationHashingPlugin } from './plugins/TranslationHashingPlugin';
 
 const { branch = 'null', commit = 'null' } = envCI();
 
@@ -239,6 +240,22 @@ export const baseOptions = ({
 						reuseExistingChunk: true,
 						enforce: true,
 					},
+					// i18n manifest modules
+					i18nManifests: {
+						chunks: 'all',
+						test: /i18n-manifest/,
+						name(module) {
+							// Keep the original name for i18n manifest files
+							const moduleFileName = module.identifier().split('/').pop();
+							if (moduleFileName && moduleFileName.includes('i18n-manifest')) {
+								return moduleFileName.replace('.js', '');
+							}
+							return 'i18n-manifests';
+						},
+						priority: 90,
+						reuseExistingChunk: true,
+						enforce: true,
+					},
 				},
 			},
 			moduleIds: 'deterministic',
@@ -438,6 +455,12 @@ export const baseOptions = ({
 						? resolve(PROJECT_ROOT, 'dist')
 						: resolve(PROJECT_ROOT, 'dist', buildEnv),
 				includeChunks: true,
+			}),
+			new TranslationHashingPlugin({
+				publicPath: guruConfig.publicPath ? `${guruConfig.publicPath}locales/` : '/locales/',
+				outputPath: 'locales/',
+				localesDir: 'public/locales',
+				hashLength: 8,
 			}),
 			new SourceMapDevToolPlugin({
 				exclude: standalone

--- a/packages/gdu/config/webpack/webpack.config.ts
+++ b/packages/gdu/config/webpack/webpack.config.ts
@@ -246,8 +246,14 @@ export const baseOptions = ({
 						test: /i18n-manifest/,
 						name(module) {
 							// Keep the original name for i18n manifest files
-							const moduleFileName = module.identifier().split('/').pop();
-							if (moduleFileName && moduleFileName.includes('i18n-manifest')) {
+							const moduleFileName = module
+								.identifier()
+								.split('/')
+								.pop();
+							if (
+								moduleFileName &&
+								moduleFileName.includes('i18n-manifest')
+							) {
 								return moduleFileName.replace('.js', '');
 							}
 							return 'i18n-manifests';
@@ -457,7 +463,9 @@ export const baseOptions = ({
 				includeChunks: true,
 			}),
 			new TranslationHashingPlugin({
-				publicPath: guruConfig.publicPath ? `${guruConfig.publicPath}locales/` : '/locales/',
+				publicPath: guruConfig.publicPath
+					? `${guruConfig.publicPath}locales/`
+					: '/locales/',
 				outputPath: 'locales/',
 				localesDir: 'public/locales',
 				hashLength: 8,


### PR DESCRIPTION
## Summary

This PR introduces a new webpack plugin for handling internationalisation (i18n) translations with content-based hashing and manifest generation.

## Changes

### ✨ New Features
- **TranslationHashingPlugin**: A webpack plugin that processes translation files with content-based hashing
  - Generates hashed filenames for translation JSON files
  - Creates per-locale manifest modules for dynamic imports
  - Produces a master manifest for centralised translation management
  - Integrates with the build manifest for i18n metadata

### 🔧 Configuration
- Added TranslationHashingPlugin to webpack configuration
- Configured plugin with appropriate paths and options for the build process

### 📝 Documentation & Tooling
- Added Claude command configurations for development workflow
  - `/commit`: Semantic commit message formatting
  - `/lint`: Code linting with auto-fix support
  - `/pr`: Pull request creation and updates
  - `/yarn`: Dependency installation and formatting

### 🎨 Code Formatting
- Applied consistent code formatting across modified files
- Fixed line endings in readme files

## Implementation Details

The TranslationHashingPlugin provides:

| Feature | Description |
|---------|-------------|
| Content Hashing | MD5-based hashing of translation files for cache busting |
| Manifest Generation | Creates JavaScript modules for translation loading |
| Dynamic Imports | Supports lazy loading of locale-specific translations |
| SSR Support | Provides static manifest access for server-side rendering |
| Build Integration | Updates build manifest with i18n information |

## File Structure

```
locales/
├── en/
│   ├── common.[hash].json
│   └── errors.[hash].json
└── fr/
    ├── common.[hash].json
    └── errors.[hash].json

Output:
├── i18n-manifest-en.[hash].js
├── i18n-manifest-fr.[hash].js
├── i18n-master-manifest.[hash].js
└── i18n-master-manifest.json
```

## Testing

- [ ] Plugin processes translation files correctly
- [ ] Manifest modules are generated with proper exports
- [ ] Build manifest includes i18n metadata
- [ ] Dynamic imports work as expected