### PR TITLE
feat(gdu): add empty manifest generation for MFEs without translations

### DIFF
--- a/.changeset/gold-monkeys-decide.md
+++ b/.changeset/gold-monkeys-decide.md
@@ -1,0 +1,5 @@
+---
+'gdu': minor
+---
+
+Allows for empty i18n manfiest files to be created


### PR DESCRIPTION
## Summary

This PR adds support for generating empty i18n manifest files for micro-frontends (MFEs) that don't require localisation. This ensures consistent build output and prevents runtime errors when MFEs don't have a locales directory.

## Changes

- Added `generateEmptyManifests` method to `TranslationHashingPlugin` that creates placeholder manifest files
- Modified the plugin to generate empty manifests when no locales directory exists
- Empty manifests include stub implementations of all expected i18n functions

## Technical Details

When no `locales` directory is found, the plugin now:
1. Generates an empty master manifest with stub functions
2. Creates a metadata JSON file marking it as empty
3. Ensures consistent build output across all MFEs

This change allows MFEs without localisation requirements to build successfully without needing to create dummy translation files.

## Testing

- Build an MFE without a locales directory
- Verify that empty manifest files are generated
- Confirm no runtime errors occur when loading the MFE