### PR TITLE
feat(AG-20098): GDU Vite 8 upgrade

### DIFF
--- a/.changeset/AG-20098-gdu-vite-8.md
+++ b/.changeset/AG-20098-gdu-vite-8.md
@@ -1,0 +1,19 @@
+---
+"gdu": minor
+---
+
+feat(AG-20098): upgrade GDU to Vite 8 stable and drop the single-config bake
+
+The SPA build now runs on Vite 8 stable (`^8.1.3`), replacing the
+`^8.0.0-beta.0` pin. Rolldown + OXC were already the active bundler/transform
+path, so this is a version bump plus verification across the pilot SPA dev
+server and production artefact build.
+
+`mfeEnvTokens` no longer bakes a `globalThis.__MFE_ENV__={...}` init block into
+the `mfe-configs` chunk. It keeps only its `process.env.X` →
+`globalThis.__MFE_ENV__["X"]` key rewrite; initialising `__MFE_ENV__` moves to
+the per-env/tenant config chunks emitted by `multiEnvConfigEmitter`
+(04-gdu-vite8.md §2.3), landing separately. Until that emitter lands, the
+production SPA artefact carries the config-key rewrites without an init block —
+harmless while no consumer bumps its `gdu` dependency. The dev server is
+unaffected (the plugin is build-only).

--- a/bun.lock
+++ b/bun.lock
@@ -170,7 +170,7 @@
         "ts-node": "^9.0.0",
         "tsconfig-paths-webpack-plugin": "^3.5.2",
         "url-loader": "^4.1.1",
-        "vite": "^8.0.0-beta.0",
+        "vite": "^8.1.3",
         "vite-tsconfig-paths": "^5.1.0",
         "webpack": "5.96.1",
         "webpack-dev-server": "^5.2.0",
@@ -3502,7 +3502,7 @@
 
     "verror": ["verror@1.10.0", "", { "dependencies": { "assert-plus": "^1.0.0", "core-util-is": "1.0.2", "extsprintf": "^1.2.0" } }, "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw=="],
 
-    "vite": ["vite@8.0.0", "", { "dependencies": { "@oxc-project/runtime": "0.115.0", "lightningcss": "^1.32.0", "picomatch": "^4.0.3", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.9", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.0.0-alpha.31", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q=="],
+    "vite": ["vite@8.1.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.16", "rolldown": "~1.1.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA=="],
 
     "vite-node": ["vite-node@6.0.0", "", { "dependencies": { "cac": "^7.0.0", "es-module-lexer": "^2.0.0", "obug": "^2.1.1", "pathe": "^2.0.3", "vite": "^8.0.0" }, "bin": { "vite-node": "dist/cli.mjs" } }, "sha512-oj4PVrT+pDh6GYf5wfUXkcZyekYS8kKPfLPXVl8qe324Ec6l4K2DUKNadRbZ3LQl0qGcDz+PyOo7ZAh00Y+JjQ=="],
 
@@ -3837,6 +3837,8 @@
     "@unrs/resolver-binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
     "@vanilla-extract/compiler/@vanilla-extract/integration": ["@vanilla-extract/integration@8.0.9", "", { "dependencies": { "@babel/core": "^7.23.9", "@babel/plugin-syntax-typescript": "^7.23.3", "@vanilla-extract/babel-plugin-debug-ids": "^1.2.2", "@vanilla-extract/css": "^1.19.1", "dedent": "^1.5.3", "esbuild": "npm:esbuild@>=0.17.6 <0.28.0", "eval": "0.1.8", "find-up": "^5.0.0", "javascript-stringify": "^2.0.1", "mlly": "^1.4.2" } }, "sha512-NP+CSo5IYHDmkMMy5vAxY4R9i2+CAg4sxgvVaxuHiuY9q30i6dNUTujNNKZGW2urEkd4HVVI6NggeIyYjbGPwA=="],
+
+    "@vanilla-extract/compiler/vite": ["vite@8.0.0", "", { "dependencies": { "@oxc-project/runtime": "0.115.0", "lightningcss": "^1.32.0", "picomatch": "^4.0.3", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.9", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.0.0-alpha.31", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q=="],
 
     "@vanilla-extract/integration/@vanilla-extract/css": ["@vanilla-extract/css@1.18.0", "", { "dependencies": { "@emotion/hash": "^0.9.0", "@vanilla-extract/private": "^1.0.9", "css-what": "^6.1.0", "cssesc": "^3.0.0", "csstype": "^3.2.3", "dedent": "^1.5.3", "deep-object-diff": "^1.1.9", "deepmerge": "^4.2.2", "lru-cache": "^10.4.3", "media-query-parser": "^2.0.2", "modern-ahocorasick": "^1.0.0", "picocolors": "^1.0.0" } }, "sha512-/p0dwOjr0o8gE5BRQ5O9P0u/2DjUd6Zfga2JGmE4KaY7ZITWMszTzk4x4CPlM5cKkRr2ZGzbE6XkuPNfp9shSQ=="],
 
@@ -4544,9 +4546,17 @@
 
     "v8-to-istanbul/convert-source-map": ["convert-source-map@1.7.0", "", { "dependencies": { "safe-buffer": "~5.1.1" } }, "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA=="],
 
-    "vite/postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+    "vite/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "vite/postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
+
+    "vite/rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
+
+    "vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "vite-node/es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
+
+    "vite-node/vite": ["vite@8.0.0", "", { "dependencies": { "@oxc-project/runtime": "0.115.0", "lightningcss": "^1.32.0", "picomatch": "^4.0.3", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.9", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.0.0-alpha.31", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q=="],
 
     "webpack/browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
@@ -4667,6 +4677,8 @@
     "@vanilla-extract/compiler/@vanilla-extract/integration/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
     "@vanilla-extract/compiler/@vanilla-extract/integration/eval": ["eval@0.1.8", "", { "dependencies": { "@types/node": "*", "require-like": ">= 0.1.1" } }, "sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw=="],
+
+    "@vanilla-extract/compiler/vite/postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
     "@vanilla-extract/vite-plugin/@vanilla-extract/integration/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
@@ -5310,6 +5322,44 @@
 
     "v8-to-istanbul/convert-source-map/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
+    "vite-node/vite/postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+
+    "vite/postcss/nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
+
+    "vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
+
+    "vite/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
+
+    "vite/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
+
+    "vite/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g=="],
+
+    "vite/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA=="],
+
+    "vite/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.5", "", { "os": "linux", "cpu": "arm" }, "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw=="],
+
+    "vite/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q=="],
+
+    "vite/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA=="],
+
+    "vite/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg=="],
+
+    "vite/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA=="],
+
+    "vite/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ=="],
+
+    "vite/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg=="],
+
+    "vite/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.5", "", { "os": "none", "cpu": "arm64" }, "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA=="],
+
+    "vite/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw=="],
+
+    "vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
+
+    "vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
     "webpack-dev-middleware/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "webpack-dev-server/open/define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
@@ -5460,6 +5510,12 @@
 
     "unset-value/has-value/isobject/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
     "@graphql-cli/common/@graphql-tools/load/@graphql-tools/utils/camel-case/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "@graphql-cli/common/graphql-config/@graphql-tools/utils/camel-case/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
@@ -5508,6 +5564,14 @@
 
     "svgo/css-select/domutils/dom-serializer/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
     "find-cache-dir/pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@4.0.0", "", { "dependencies": { "yocto-queue": "^1.0.0" } }, "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ=="],
 
     "graphql-schema-diff/@graphql-tools/url-loader/@graphql-tools/wrap/@graphql-tools/schema/@graphql-tools/utils/tslib": ["tslib@2.5.0", "", {}, "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="],
@@ -5515,6 +5579,8 @@
     "resolve-url-loader/postcss/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
     "sane/micromatch/braces/fill-range/is-number/kind-of": ["kind-of@3.2.2", "", { "dependencies": { "is-buffer": "^1.1.5" } }, "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "find-cache-dir/pkg-dir/find-up/locate-path/p-locate/p-limit/yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
   }

--- a/packages/gdu/config/vite/plugins/__tests__/mfeEnvTokens.test.ts
+++ b/packages/gdu/config/vite/plugins/__tests__/mfeEnvTokens.test.ts
@@ -1,0 +1,86 @@
+import { mfeEnvTokens } from '../mfeEnvTokens';
+
+type TransformFn = (code: string) => { code: string; map: null } | null;
+
+function getTransform(plugin: ReturnType<typeof mfeEnvTokens>): TransformFn {
+	const hook = plugin.transform;
+	if (typeof hook === 'function') {
+		return hook.bind(null) as unknown as TransformFn;
+	}
+	throw new Error('expected transform to be a function hook');
+}
+
+const envTokens = {
+	IS_PRODUCTION: '"#{IS_PRODUCTION}"',
+	BASE_URL: '"#{BASE_URL}"',
+};
+
+describe('mfeEnvTokens', () => {
+	describe('when no tokens are provided', () => {
+		it('returns a no-op plugin with only a name', () => {
+			const plugin = mfeEnvTokens({});
+			expect(plugin.name).toBe('gdu-mfe-env-tokens');
+			expect(plugin).not.toHaveProperty('transform');
+			expect(plugin).not.toHaveProperty('renderChunk');
+		});
+	});
+
+	describe('when tokens are provided', () => {
+		it('applies only at build time, before define', () => {
+			const plugin = mfeEnvTokens(envTokens);
+			expect(plugin.apply).toBe('build');
+			expect(plugin.enforce).toBe('pre');
+		});
+
+		it('rewrites process.env reads to globalThis.__MFE_ENV__ lookups', () => {
+			const transform = getTransform(mfeEnvTokens(envTokens));
+
+			const result = transform('const a = process.env.BASE_URL;');
+
+			expect(result).toEqual({
+				code: 'const a = globalThis.__MFE_ENV__["BASE_URL"];',
+				map: null,
+			});
+		});
+
+		it('rewrites every occurrence of every tracked key', () => {
+			const transform = getTransform(mfeEnvTokens(envTokens));
+
+			const result = transform(
+				'a(process.env.BASE_URL);b(process.env.IS_PRODUCTION);c(process.env.BASE_URL);',
+			);
+
+			expect(result).toEqual({
+				code: 'a(globalThis.__MFE_ENV__["BASE_URL"]);b(globalThis.__MFE_ENV__["IS_PRODUCTION"]);c(globalThis.__MFE_ENV__["BASE_URL"]);',
+				map: null,
+			});
+		});
+
+		it('does not rewrite keys that are only a prefix of the source token', () => {
+			const transform = getTransform(mfeEnvTokens(envTokens));
+
+			const result = transform('const a = process.env.BASE_URLX;');
+
+			expect(result).toBeNull();
+		});
+
+		it('leaves untracked process.env keys untouched', () => {
+			const transform = getTransform(mfeEnvTokens(envTokens));
+
+			const result = transform('const a = process.env.NOT_TRACKED;');
+
+			expect(result).toBeNull();
+		});
+
+		it('returns null when the code has no process.env reads', () => {
+			const transform = getTransform(mfeEnvTokens(envTokens));
+
+			expect(transform('const a = 1;')).toBeNull();
+		});
+
+		it('does not bake an init block into any chunk (owned by multiEnvConfigEmitter)', () => {
+			const plugin = mfeEnvTokens(envTokens);
+			expect(plugin).not.toHaveProperty('renderChunk');
+		});
+	});
+});

--- a/packages/gdu/config/vite/plugins/mfeEnvTokens.ts
+++ b/packages/gdu/config/vite/plugins/mfeEnvTokens.ts
@@ -1,18 +1,26 @@
 import type { VitePlugin } from '../types';
 
 /**
- * Prevents Rolldown from constant-folding Octopus deploy tokens across chunks.
+ * Rewrites `process.env.XXX` reads to `globalThis.__MFE_ENV__["XXX"]` so
+ * per-env/tenant config can be injected as a separate chunk rather than
+ * constant-folded into application code.
  *
- * Problem: Vite's `define` replaces `process.env.XXX` with a string literal
- * (e.g. `"#{IS_PRODUCTION}"`). Rolldown then inlines that literal into every
- * consumer chunk, scattering tokens across dozens of files. The CI/CD
- * `tokenReplacement.sh` only processes the `mfe-configs` chunk, so scattered
- * tokens remain un-replaced at runtime.
+ * Problem: Vite's `define` replaces `process.env.XXX` with a string literal.
+ * Rolldown then inlines that literal into every consumer chunk, scattering
+ * config across dozens of files — impossible to swap per env/tenant at build
+ * time.
  *
  * Solution: This plugin runs before `define` (`enforce: 'pre'`) and rewrites
  * `process.env.XXX` → `globalThis.__MFE_ENV__["XXX"]`. Dynamic property access
- * cannot be constant-folded, so all tokens stay inside the `mfe-configs` chunk
- * where `tokenReplacement.sh` can find them.
+ * cannot be constant-folded, so every config read resolves through a single
+ * `globalThis.__MFE_ENV__` object at runtime, keeping application chunk bytes
+ * independent of which env's values are in play.
+ *
+ * The `globalThis.__MFE_ENV__` object itself is initialised by
+ * `multiEnvConfigEmitter` (04-gdu-vite8.md §2.3, lands in PR13 / AG-20099),
+ * which emits one config chunk per env×tenant combo. This plugin owns only the
+ * key-name rewrite; it no longer bakes an init block into the `mfe-configs`
+ * chunk.
  */
 export function mfeEnvTokens(envTokens: Record<string, string>): VitePlugin {
 	const keys = Object.keys(envTokens);
@@ -28,11 +36,6 @@ export function mfeEnvTokens(envTokens: Record<string, string>): VitePlugin {
 		'g',
 	);
 
-	const initEntries = keys
-		.map((key) => `${JSON.stringify(key)}:${envTokens[key]}`)
-		.join(',');
-	const initCode = `globalThis.__MFE_ENV__={${initEntries}};`;
-
 	return {
 		name: 'gdu-mfe-env-tokens',
 		apply: 'build',
@@ -47,11 +50,6 @@ export function mfeEnvTokens(envTokens: Record<string, string>): VitePlugin {
 			);
 
 			return result === code ? null : { code: result, map: null };
-		},
-
-		renderChunk(code, chunk) {
-			if (!chunk.fileName.includes('mfe-configs')) return null;
-			return { code: initCode + code, map: null };
 		},
 	};
 }

--- a/packages/gdu/config/vite/vite.config.ts
+++ b/packages/gdu/config/vite/vite.config.ts
@@ -137,9 +137,11 @@ export const baseViteOptions = ({
 			__GDU_APP_NAME__: JSON.stringify(getProjectName()),
 			__GDU_BUILD_INFO__: JSON.stringify({ commit, branch }),
 			// In production builds, mfeEnvTokens (enforce: 'pre') rewrites
-			// process.env.X to globalThis.__MFE_ENV__[X] before `define` runs,
-			// so these entries only take effect in dev mode where the plugin
-			// is disabled (apply: 'build').
+			// process.env.X to globalThis.__MFE_ENV__["X"] before `define` runs
+			// (the __MFE_ENV__ object is emitted as a separate per-env/tenant
+			// config chunk by multiEnvConfigEmitter, PR13 / AG-20099), so these
+			// entries only take effect in dev mode where the plugin is disabled
+			// (apply: 'build').
 			...envDefines,
 		},
 

--- a/packages/gdu/package.json
+++ b/packages/gdu/package.json
@@ -88,7 +88,7 @@
 		"ts-node": "^9.0.0",
 		"tsconfig-paths-webpack-plugin": "^3.5.2",
 		"url-loader": "^4.1.1",
-		"vite": "^8.0.0-beta.0",
+		"vite": "^8.1.3",
 		"vite-tsconfig-paths": "^5.1.0",
 		"webpack": "5.96.1",
 		"webpack-dev-server": "^5.2.0",


### PR DESCRIPTION
## What

UD PR12 (AG-20098). Upgrades GDU to Vite 8 stable and drops the `mfeEnvTokens` single-config bake, per `docs/unified-deployments/04-gdu-vite8.md`.

- Bump the SPA build's vite pin `^8.0.0-beta.0` → `^8.1.3` (first stable 8.x). Rolldown and OXC were already the active bundler/transform path in GDU, so this is a version bump plus verification, not a fresh adoption.
- Remove the `renderChunk` hook from `mfeEnvTokens` (it baked `globalThis.__MFE_ENV__={...}` into the `mfe-configs` chunk). The plugin now keeps only its `process.env.X` → `globalThis.__MFE_ENV__["X"]` key rewrite, per 04 §3.
- New unit test for the trimmed plugin; JSDoc/comments updated; `minor` changeset.

## Scope boundary (PR12 vs PR13)

Per `04` §3–§4 and `07-migration-plan.md` §4, initialising `globalThis.__MFE_ENV__` moves to the per-env/tenant config chunks emitted by `multiEnvConfigEmitter`, which is **PR13 (AG-20099)** and depends on this PR. This PR intentionally does not add that plugin.

**Interim consequence (by design):** with the bake removed and the emitter not yet landed, the production SPA artefact reads `globalThis.__MFE_ENV__.<key>` but nothing initialises `__MFE_ENV__`, so the prod bundle throws a `TypeError` on first config access until PR13 lands. This is the documented decomposition — `08-validation-workflows.md` §2.2 step 4 explicitly relaxes prod validation to "artefact + manifest produced" for exactly this window — and it is harmless because no consumer bumps the `gdu` dependency until PR14, which depends on PR13. **The dev server is unaffected** (the plugin is `apply: 'build'`, disabled in dev; dev inlines config via Vite `define`).

## Validation — Workflow A (`08-validation-workflows.md` §2), pilot app `fls-booking`

GDU was built from this branch and linked into the mfe checkout (`gdu/dist` + `gdu/entry` + `@autoguru/babel-preset`), then restored to registry `13.20.1` afterwards (zero diff left in the mfe checkout).

| Step | Action | Result |
|---|---|---|
| 1. Link local GDU | Build GDU (`tsc`) from this branch, copy artefacts into `mfe/node_modules` | Pass — build clean; swapped `mfeEnvTokens.js` confirmed no `renderChunk` |
| 2. Dev render (au) | Vite 8 dev server, `APP_ENV=dev_au`, port 8091 | Pass — server boots + optimises deps; `/` (Accept: text/html) → 200 serving the `Fleet Supplier Booking \| LOCAL` shell with `/@vite/client`; entry `client.js` → 200; app `src/client.tsx` transforms (oxc JSX) → 200; no transform errors in log |
| 3. Dev render (nz) | Config-emission change is build-only and tenant-agnostic; tenant dimension validated at build level (step 6) | Covered via step 6 |
| 4. Prod artefact build | `NODE_ENV=production APP_ENV=dev_au bun run build:mfe` | Pass — built in 25s; `dist/dev_au/build-manifest.json` produced (relaxed pre-emitter criterion met) |
| 5. Local prod-serve | `mfe-local-prod-server.js fls-booking dev au 8092` | Server boots + serves artefact (index → 200, `main-*.js` → 200). Client render is blocked on `__MFE_ENV__` init (the PR13 gap above), which is the intended pre-emitter state |
| 6. Both tenants | Prod build `dev_au` **and** `dev_nz` | Pass — both produce artefact + manifest; `mfe-configs` chunk carries `globalThis.__MFE_ENV__.<key>` reads with **no** init block (init-block count 0), tenant-agnostic |

Static evidence for the removal: the fresh Vite 8 `dev_au` `mfe-configs` chunk begins `import{n as e}from"./chunks/rolldown-runtime-*.js";var t,n=e(()=>{t=globalThis.__MFE_ENV__.agApiKey})...` (reads, no assignment), versus a stale old-GDU build of the same chunk which began `globalThis.__MFE_ENV__={authRedirectApp:...}` (init present).

## Sourcemap emission stance (04 §2.7) — not regressed under Vite 8

`sourcemap: 'hidden'` (`vite.config.ts:152`) is untouched by this PR. Verified against a fresh Vite 8 `dev_au` prod build of fls-booking:

- **Maps emitted:** 207 `.js.map` files for 220 `.js` chunks (the 13 without maps are trivial locale/manifest emit chunks); `main-*.js`, component chunks, and `mfe-configs-*.js` each have a valid v3 `.map` (checked `version:3` + populated `mappings`/`sources`).
- **Hidden confirmed:** no real trailing `//# sourceMappingURL=<file>.map` comment in any `.js` (the JS ends at its export map, not a pointer). So 03's Datadog upload has maps to send, and the shipped bundle carries no browser-discoverable pointer.
- **Doc note:** 04 §2.7's acceptance ("grep `dist/*.js` for `sourceMappingURL` returns empty") false-positives — one bundled dependency constructs the literal string `"//# sourceMappingURL=" + r` in its own code. The meaningful assertion is "no trailing `//[#@] sourceMappingURL=…\.map` comment", which holds. Suggest tightening that grep in a future 04 edit.

## Notes for reviewers

- **Pre-existing, unrelated CI failure:** `packages/browserslist-config/test.spec.js` fails a snapshot (`chrome 138`/`edge 138` dropped). This is date-driven browserslist drift — the snapshot was last updated 2026-06-02 (#437, CI green then) and `browserslist` resolves browser sets relative to the current date. The `caniuse-lite` pins are byte-identical to `origin/main`, and this PR touches nothing under `packages/browserslist-config`. It will fail any CI run today regardless of this change; deliberately not folded in here to keep the diff focused (belongs in a separate repo-hygiene fix).
- `sp-global-notification` (the last webpack SPA, 04 §2.6) and the fleet-wide `bundler: 'vite'` flip are mfe-repo changes and out of scope for this octane PR.

Design refs: `04-gdu-vite8.md`, `08-validation-workflows.md` §2.
