### PR TITLE
feat(AG-20099): multi-env manifest emission

### DIFF
--- a/.changeset/AG-20098-gdu-vite-8.md
+++ b/.changeset/AG-20098-gdu-vite-8.md
@@ -1,0 +1,19 @@
+---
+"gdu": minor
+---
+
+feat(AG-20098): upgrade GDU to Vite 8 stable and drop the single-config bake
+
+The SPA build now runs on Vite 8 stable (`^8.1.3`), replacing the
+`^8.0.0-beta.0` pin. Rolldown + OXC were already the active bundler/transform
+path, so this is a version bump plus verification across the pilot SPA dev
+server and production artefact build.
+
+`mfeEnvTokens` no longer bakes a `globalThis.__MFE_ENV__={...}` init block into
+the `mfe-configs` chunk. It keeps only its `process.env.X` →
+`globalThis.__MFE_ENV__["X"]` key rewrite; initialising `__MFE_ENV__` moves to
+the per-env/tenant config chunks emitted by `multiEnvConfigEmitter`
+(04-gdu-vite8.md §2.3), landing separately. Until that emitter lands, the
+production SPA artefact carries the config-key rewrites without an init block —
+harmless while no consumer bumps its `gdu` dependency. The dev server is
+unaffected (the plugin is build-only).

--- a/.changeset/AG-20099-multi-env-manifest.md
+++ b/.changeset/AG-20099-multi-env-manifest.md
@@ -1,0 +1,20 @@
+---
+"gdu": minor
+---
+
+feat(AG-20099): emit per-env/tenant config scripts and multi-env build manifest
+
+Adds `multiEnvConfigEmitter`, which emits one init-only
+`mfe-configs-<env>_<tenant>-<hash>.js` script per env×tenant combo an SPA
+targets (read from `.mfe-data/mfe-list.json`), each a standalone
+`globalThis.__MFE_ENV__={...}` assignment carrying that combo's real, resolved
+config values (merged from `.mfe-data/env-configs` + `.mfe-data/app-configs`,
+restricted to the keys the app actually reads). The host injects the matching
+script ahead of the app bundle so config is initialised without a `sed` step.
+
+`guruBuildManifest` now records these scripts in an `env` map
+(`env[<env>_<tenant>].config`) per the 00-overview §4c schema. The `mfe-configs`
+app chunk is left intact and env-agnostic — its bytes (and hash) no longer
+depend on which env's values are in play, so the app bundle is identical across
+combos while only the tiny config scripts differ. A shared `mfeDataReader`
+resolves combos and merges config sources.

--- a/bun.lock
+++ b/bun.lock
@@ -170,7 +170,7 @@
         "ts-node": "^9.0.0",
         "tsconfig-paths-webpack-plugin": "^3.5.2",
         "url-loader": "^4.1.1",
-        "vite": "^8.0.0-beta.0",
+        "vite": "^8.1.3",
         "vite-tsconfig-paths": "^5.1.0",
         "webpack": "5.96.1",
         "webpack-dev-server": "^5.2.0",
@@ -3502,7 +3502,7 @@
 
     "verror": ["verror@1.10.0", "", { "dependencies": { "assert-plus": "^1.0.0", "core-util-is": "1.0.2", "extsprintf": "^1.2.0" } }, "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw=="],
 
-    "vite": ["vite@8.0.0", "", { "dependencies": { "@oxc-project/runtime": "0.115.0", "lightningcss": "^1.32.0", "picomatch": "^4.0.3", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.9", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.0.0-alpha.31", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q=="],
+    "vite": ["vite@8.1.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.16", "rolldown": "~1.1.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA=="],
 
     "vite-node": ["vite-node@6.0.0", "", { "dependencies": { "cac": "^7.0.0", "es-module-lexer": "^2.0.0", "obug": "^2.1.1", "pathe": "^2.0.3", "vite": "^8.0.0" }, "bin": { "vite-node": "dist/cli.mjs" } }, "sha512-oj4PVrT+pDh6GYf5wfUXkcZyekYS8kKPfLPXVl8qe324Ec6l4K2DUKNadRbZ3LQl0qGcDz+PyOo7ZAh00Y+JjQ=="],
 
@@ -3837,6 +3837,8 @@
     "@unrs/resolver-binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
     "@vanilla-extract/compiler/@vanilla-extract/integration": ["@vanilla-extract/integration@8.0.9", "", { "dependencies": { "@babel/core": "^7.23.9", "@babel/plugin-syntax-typescript": "^7.23.3", "@vanilla-extract/babel-plugin-debug-ids": "^1.2.2", "@vanilla-extract/css": "^1.19.1", "dedent": "^1.5.3", "esbuild": "npm:esbuild@>=0.17.6 <0.28.0", "eval": "0.1.8", "find-up": "^5.0.0", "javascript-stringify": "^2.0.1", "mlly": "^1.4.2" } }, "sha512-NP+CSo5IYHDmkMMy5vAxY4R9i2+CAg4sxgvVaxuHiuY9q30i6dNUTujNNKZGW2urEkd4HVVI6NggeIyYjbGPwA=="],
+
+    "@vanilla-extract/compiler/vite": ["vite@8.0.0", "", { "dependencies": { "@oxc-project/runtime": "0.115.0", "lightningcss": "^1.32.0", "picomatch": "^4.0.3", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.9", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.0.0-alpha.31", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q=="],
 
     "@vanilla-extract/integration/@vanilla-extract/css": ["@vanilla-extract/css@1.18.0", "", { "dependencies": { "@emotion/hash": "^0.9.0", "@vanilla-extract/private": "^1.0.9", "css-what": "^6.1.0", "cssesc": "^3.0.0", "csstype": "^3.2.3", "dedent": "^1.5.3", "deep-object-diff": "^1.1.9", "deepmerge": "^4.2.2", "lru-cache": "^10.4.3", "media-query-parser": "^2.0.2", "modern-ahocorasick": "^1.0.0", "picocolors": "^1.0.0" } }, "sha512-/p0dwOjr0o8gE5BRQ5O9P0u/2DjUd6Zfga2JGmE4KaY7ZITWMszTzk4x4CPlM5cKkRr2ZGzbE6XkuPNfp9shSQ=="],
 
@@ -4544,9 +4546,17 @@
 
     "v8-to-istanbul/convert-source-map": ["convert-source-map@1.7.0", "", { "dependencies": { "safe-buffer": "~5.1.1" } }, "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA=="],
 
-    "vite/postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+    "vite/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "vite/postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
+
+    "vite/rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
+
+    "vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "vite-node/es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
+
+    "vite-node/vite": ["vite@8.0.0", "", { "dependencies": { "@oxc-project/runtime": "0.115.0", "lightningcss": "^1.32.0", "picomatch": "^4.0.3", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.9", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.0.0-alpha.31", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q=="],
 
     "webpack/browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
@@ -4667,6 +4677,8 @@
     "@vanilla-extract/compiler/@vanilla-extract/integration/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
     "@vanilla-extract/compiler/@vanilla-extract/integration/eval": ["eval@0.1.8", "", { "dependencies": { "@types/node": "*", "require-like": ">= 0.1.1" } }, "sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw=="],
+
+    "@vanilla-extract/compiler/vite/postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
     "@vanilla-extract/vite-plugin/@vanilla-extract/integration/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
@@ -5310,6 +5322,44 @@
 
     "v8-to-istanbul/convert-source-map/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
+    "vite-node/vite/postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+
+    "vite/postcss/nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
+
+    "vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
+
+    "vite/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
+
+    "vite/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
+
+    "vite/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g=="],
+
+    "vite/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA=="],
+
+    "vite/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.5", "", { "os": "linux", "cpu": "arm" }, "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw=="],
+
+    "vite/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q=="],
+
+    "vite/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA=="],
+
+    "vite/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg=="],
+
+    "vite/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA=="],
+
+    "vite/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ=="],
+
+    "vite/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg=="],
+
+    "vite/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.5", "", { "os": "none", "cpu": "arm64" }, "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA=="],
+
+    "vite/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw=="],
+
+    "vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
+
+    "vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
     "webpack-dev-middleware/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "webpack-dev-server/open/define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
@@ -5460,6 +5510,12 @@
 
     "unset-value/has-value/isobject/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
     "@graphql-cli/common/@graphql-tools/load/@graphql-tools/utils/camel-case/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "@graphql-cli/common/graphql-config/@graphql-tools/utils/camel-case/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
@@ -5508,6 +5564,14 @@
 
     "svgo/css-select/domutils/dom-serializer/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
     "find-cache-dir/pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@4.0.0", "", { "dependencies": { "yocto-queue": "^1.0.0" } }, "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ=="],
 
     "graphql-schema-diff/@graphql-tools/url-loader/@graphql-tools/wrap/@graphql-tools/schema/@graphql-tools/utils/tslib": ["tslib@2.5.0", "", {}, "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="],
@@ -5515,6 +5579,8 @@
     "resolve-url-loader/postcss/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
     "sane/micromatch/braces/fill-range/is-number/kind-of": ["kind-of@3.2.2", "", { "dependencies": { "is-buffer": "^1.1.5" } }, "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "find-cache-dir/pkg-dir/find-up/locate-path/p-locate/p-limit/yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
   }

--- a/packages/gdu/config/vite/plugins/GuruBuildManifest.ts
+++ b/packages/gdu/config/vite/plugins/GuruBuildManifest.ts
@@ -19,6 +19,10 @@ interface I18nMetadata {
 	supportedLocales: string[];
 }
 
+export interface EnvConfigEntry {
+	config: string;
+}
+
 export interface Manifest {
 	hash: string;
 	mountDOMId?: string;
@@ -27,7 +31,18 @@ export interface Manifest {
 	assets: Asset;
 	chunks?: Asset;
 	i18n?: I18nMetadata;
+	env?: Record<string, EnvConfigEntry>;
 }
+
+/**
+ * `mfe-configs-<env>_<tenant>-<hash>.js` — a per-env/tenant config chunk emitted
+ * by `multiEnvConfigEmitter`. The `<env>_<tenant>` infix distinguishes it from
+ * the env-agnostic un-infixed `mfe-configs-<hash>.js` app chunk and from any
+ * confusably named component chunk (e.g. `mfe-configs-panel-*`), which do not
+ * match.
+ */
+const ENV_CONFIG_CHUNK_RE =
+	/^mfe-configs-([a-z]+_[a-z]{2})-[a-zA-Z\d]{8}\.js$/;
 
 interface GuruBuildManifestOptions {
 	mountDOMId?: string;
@@ -97,6 +112,26 @@ export function collectEntryCssFiles(
 	}
 
 	return entryCssFiles;
+}
+
+/**
+ * Builds the manifest `env` map from the emitted config-chunk filenames, keyed
+ * by `<env>_<tenant>`. Each filename is prefixed with `publicPath` identically to
+ * `assets`/`chunks` (bare when `publicPath` is empty, the default). Keys are
+ * sorted so the emitted manifest bytes are stable across builds.
+ */
+export function collectEnvConfigChunks(
+	fileNames: string[],
+	publicPath = '',
+): Record<string, EnvConfigEntry> {
+	const env: Record<string, EnvConfigEntry> = {};
+	for (const fileName of [...fileNames].sort()) {
+		const match = ENV_CONFIG_CHUNK_RE.exec(fileName);
+		if (match) {
+			env[match[1]] = { config: `${publicPath}${fileName}` };
+		}
+	}
+	return env;
 }
 
 function classifyChunk(
@@ -200,6 +235,14 @@ export function guruBuildManifest(
 
 			if (!opts.includeChunks) {
 				result.chunks = undefined;
+			}
+
+			const env = collectEnvConfigChunks(
+				Object.keys(bundle),
+				opts.publicPath,
+			);
+			if (Object.keys(env).length > 0) {
+				result.env = env;
 			}
 
 			mergeI18nMetadata(result, bundle as any);

--- a/packages/gdu/config/vite/plugins/__tests__/GuruBuildManifest.test.ts
+++ b/packages/gdu/config/vite/plugins/__tests__/GuruBuildManifest.test.ts
@@ -1,4 +1,7 @@
-import { collectEntryCssFiles } from '../GuruBuildManifest';
+import {
+	collectEntryCssFiles,
+	collectEnvConfigChunks,
+} from '../GuruBuildManifest';
 
 type BundleChunk = {
 	type: string;
@@ -227,6 +230,58 @@ describe('collectEntryCssFiles', () => {
 				'assets/worker.css',
 				'assets/worker-dep.css',
 			]),
+		);
+	});
+});
+
+describe('collectEnvConfigChunks', () => {
+	it('byte-matches the 00-overview §4c env-map shape', () => {
+		const fileNames = [
+			'main-ab12cd34.js',
+			'chunks/Box-1a2b3c4d.js',
+			'mfe-configs-dev_au-1a2b3c4d.js',
+			'mfe-configs-dev_nz-3c4d5e6f.js',
+			'mfe-configs-prod_au-5e6f7a8b.js',
+		];
+
+		const env = collectEnvConfigChunks(fileNames);
+
+		expect(JSON.stringify(env)).toBe(
+			'{"dev_au":{"config":"mfe-configs-dev_au-1a2b3c4d.js"},' +
+				'"dev_nz":{"config":"mfe-configs-dev_nz-3c4d5e6f.js"},' +
+				'"prod_au":{"config":"mfe-configs-prod_au-5e6f7a8b.js"}}',
+		);
+	});
+
+	it('ignores the un-infixed mfe-configs app chunk', () => {
+		const env = collectEnvConfigChunks(['mfe-configs-1a2b3c4d.js']);
+		expect(env).toEqual({});
+	});
+
+	it('ignores confusably named non-config chunks', () => {
+		const env = collectEnvConfigChunks([
+			'mfe-configs-panel-1a2b3c4d.js',
+			'mfe-configs-dev_au-1a2b3c4d.css',
+			'main-1a2b3c4d.js',
+		]);
+		expect(env).toEqual({});
+	});
+
+	it('sorts combo keys for stable manifest bytes regardless of input order', () => {
+		const env = collectEnvConfigChunks([
+			'mfe-configs-prod_au-5e6f7a8b.js',
+			'mfe-configs-dev_au-1a2b3c4d.js',
+		]);
+		expect(Object.keys(env)).toEqual(['dev_au', 'prod_au']);
+	});
+
+	it('prepends the publicPath to each config path', () => {
+		const env = collectEnvConfigChunks(
+			['mfe-configs-dev_au-1a2b3c4d.js'],
+			'https://cdn/app/v1/',
+		);
+		expect(env.dev_au.config).toBe(
+			'https://cdn/app/v1/mfe-configs-dev_au-1a2b3c4d.js',
 		);
 	});
 });

--- a/packages/gdu/config/vite/plugins/__tests__/mfeEnvTokens.test.ts
+++ b/packages/gdu/config/vite/plugins/__tests__/mfeEnvTokens.test.ts
@@ -1,0 +1,86 @@
+import { mfeEnvTokens } from '../mfeEnvTokens';
+
+type TransformFn = (code: string) => { code: string; map: null } | null;
+
+function getTransform(plugin: ReturnType<typeof mfeEnvTokens>): TransformFn {
+	const hook = plugin.transform;
+	if (typeof hook === 'function') {
+		return hook.bind(null) as unknown as TransformFn;
+	}
+	throw new Error('expected transform to be a function hook');
+}
+
+const envTokens = {
+	IS_PRODUCTION: '"#{IS_PRODUCTION}"',
+	BASE_URL: '"#{BASE_URL}"',
+};
+
+describe('mfeEnvTokens', () => {
+	describe('when no tokens are provided', () => {
+		it('returns a no-op plugin with only a name', () => {
+			const plugin = mfeEnvTokens({});
+			expect(plugin.name).toBe('gdu-mfe-env-tokens');
+			expect(plugin).not.toHaveProperty('transform');
+			expect(plugin).not.toHaveProperty('renderChunk');
+		});
+	});
+
+	describe('when tokens are provided', () => {
+		it('applies only at build time, before define', () => {
+			const plugin = mfeEnvTokens(envTokens);
+			expect(plugin.apply).toBe('build');
+			expect(plugin.enforce).toBe('pre');
+		});
+
+		it('rewrites process.env reads to globalThis.__MFE_ENV__ lookups', () => {
+			const transform = getTransform(mfeEnvTokens(envTokens));
+
+			const result = transform('const a = process.env.BASE_URL;');
+
+			expect(result).toEqual({
+				code: 'const a = globalThis.__MFE_ENV__["BASE_URL"];',
+				map: null,
+			});
+		});
+
+		it('rewrites every occurrence of every tracked key', () => {
+			const transform = getTransform(mfeEnvTokens(envTokens));
+
+			const result = transform(
+				'a(process.env.BASE_URL);b(process.env.IS_PRODUCTION);c(process.env.BASE_URL);',
+			);
+
+			expect(result).toEqual({
+				code: 'a(globalThis.__MFE_ENV__["BASE_URL"]);b(globalThis.__MFE_ENV__["IS_PRODUCTION"]);c(globalThis.__MFE_ENV__["BASE_URL"]);',
+				map: null,
+			});
+		});
+
+		it('does not rewrite keys that are only a prefix of the source token', () => {
+			const transform = getTransform(mfeEnvTokens(envTokens));
+
+			const result = transform('const a = process.env.BASE_URLX;');
+
+			expect(result).toBeNull();
+		});
+
+		it('leaves untracked process.env keys untouched', () => {
+			const transform = getTransform(mfeEnvTokens(envTokens));
+
+			const result = transform('const a = process.env.NOT_TRACKED;');
+
+			expect(result).toBeNull();
+		});
+
+		it('returns null when the code has no process.env reads', () => {
+			const transform = getTransform(mfeEnvTokens(envTokens));
+
+			expect(transform('const a = 1;')).toBeNull();
+		});
+
+		it('does not bake an init block into any chunk (owned by multiEnvConfigEmitter)', () => {
+			const plugin = mfeEnvTokens(envTokens);
+			expect(plugin).not.toHaveProperty('renderChunk');
+		});
+	});
+});

--- a/packages/gdu/config/vite/plugins/__tests__/multiEnvConfigEmitter.test.ts
+++ b/packages/gdu/config/vite/plugins/__tests__/multiEnvConfigEmitter.test.ts
@@ -1,0 +1,130 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { multiEnvConfigEmitter } from '../multiEnvConfigEmitter';
+
+interface EmittedAsset {
+	type: 'asset';
+	fileName: string;
+	source: string;
+}
+
+const APP = '@autoguru/fls-booking';
+const CONFIG_CHUNK = 'mfe-configs-Zx8yQ1a2.js';
+
+function writeWorkspace(): string {
+	const root = mkdtempSync(join(tmpdir(), 'emitter-'));
+	const dataRoot = join(root, '.mfe-data');
+	mkdirSync(join(dataRoot, 'env-configs'), { recursive: true });
+	writeFileSync(
+		join(dataRoot, 'mfe-list.json'),
+		JSON.stringify({
+			spa: { 'fls-booking': { au: ['dev'], nz: ['dev'] } },
+		}),
+	);
+	writeFileSync(
+		join(dataRoot, 'env-configs', 'dev_au.json'),
+		JSON.stringify({ baseUrl: 'https://au', cdkOnly: 'x' }),
+	);
+	writeFileSync(
+		join(dataRoot, 'env-configs', 'dev_nz.json'),
+		JSON.stringify({ baseUrl: 'https://nz', cdkOnly: 'x' }),
+	);
+	return root;
+}
+
+function makePlugin(root: string) {
+	return multiEnvConfigEmitter({
+		appName: APP,
+		workspaceRoot: root,
+		envTokenMap: { baseUrl: '"#{BASE_URL}"' },
+	});
+}
+
+function runGenerateBundle(
+	plugin: ReturnType<typeof multiEnvConfigEmitter>,
+	bundleKeys: string[],
+): EmittedAsset[] {
+	const emitted: EmittedAsset[] = [];
+	const ctx = {
+		emitFile: (asset: EmittedAsset) => {
+			emitted.push(asset);
+			return asset.fileName;
+		},
+	};
+	const bundle: Record<string, { type: string; fileName: string }> = {};
+	for (const key of bundleKeys) {
+		bundle[key] = { type: 'chunk', fileName: key };
+	}
+	(
+		plugin.generateBundle as unknown as (...a: unknown[]) => void
+	).call(ctx, {}, bundle);
+	return emitted;
+}
+
+describe('multiEnvConfigEmitter', () => {
+	let root: string;
+	afterEach(() => {
+		if (root) rmSync(root, { recursive: true, force: true });
+	});
+
+	it('emits nothing when the bundle has no mfe-configs chunk', () => {
+		root = writeWorkspace();
+		const emitted = runGenerateBundle(makePlugin(root), [
+			'main-abc12345.js',
+		]);
+		expect(emitted).toHaveLength(0);
+	});
+
+	it('emits one init-only config script per combo', () => {
+		root = writeWorkspace();
+		const emitted = runGenerateBundle(makePlugin(root), [
+			CONFIG_CHUNK,
+			'main-abc12345.js',
+		]);
+
+		expect(emitted.map((a) => a.fileName).sort()).toEqual([
+			expect.stringMatching(/^mfe-configs-dev_au-[a-f0-9]{8}\.js$/),
+			expect.stringMatching(/^mfe-configs-dev_nz-[a-f0-9]{8}\.js$/),
+		]);
+	});
+
+	it('bakes allowlisted, per-combo values with no chunk body', () => {
+		root = writeWorkspace();
+		const emitted = runGenerateBundle(makePlugin(root), [CONFIG_CHUNK]);
+
+		const au = emitted.find((a) => a.fileName.includes('dev_au'))!;
+		const nz = emitted.find((a) => a.fileName.includes('dev_nz'))!;
+
+		expect(au.source).toBe(
+			'globalThis.__MFE_ENV__={"baseUrl":"https://au"};',
+		);
+		expect(nz.source).toBe(
+			'globalThis.__MFE_ENV__={"baseUrl":"https://nz"};',
+		);
+		expect(au.source).not.toContain('cdkOnly');
+	});
+
+	it('gives each combo a distinct content hash', () => {
+		root = writeWorkspace();
+		const emitted = runGenerateBundle(makePlugin(root), [CONFIG_CHUNK]);
+		expect(emitted[0].fileName).not.toBe(emitted[1].fileName);
+	});
+
+	it('emits nothing and warns when the app has no combos', () => {
+		root = writeWorkspace();
+		const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+		const plugin = multiEnvConfigEmitter({
+			appName: 'unlisted-app',
+			workspaceRoot: root,
+			envTokenMap: { baseUrl: '"#{BASE_URL}"' },
+		});
+
+		const emitted = runGenerateBundle(plugin, [CONFIG_CHUNK]);
+
+		expect(emitted).toHaveLength(0);
+		expect(warn).toHaveBeenCalled();
+		warn.mockRestore();
+	});
+});

--- a/packages/gdu/config/vite/plugins/mfeEnvTokens.ts
+++ b/packages/gdu/config/vite/plugins/mfeEnvTokens.ts
@@ -1,18 +1,26 @@
 import type { VitePlugin } from '../types';
 
 /**
- * Prevents Rolldown from constant-folding Octopus deploy tokens across chunks.
+ * Rewrites `process.env.XXX` reads to `globalThis.__MFE_ENV__["XXX"]` so
+ * per-env/tenant config can be injected as a separate chunk rather than
+ * constant-folded into application code.
  *
- * Problem: Vite's `define` replaces `process.env.XXX` with a string literal
- * (e.g. `"#{IS_PRODUCTION}"`). Rolldown then inlines that literal into every
- * consumer chunk, scattering tokens across dozens of files. The CI/CD
- * `tokenReplacement.sh` only processes the `mfe-configs` chunk, so scattered
- * tokens remain un-replaced at runtime.
+ * Problem: Vite's `define` replaces `process.env.XXX` with a string literal.
+ * Rolldown then inlines that literal into every consumer chunk, scattering
+ * config across dozens of files — impossible to swap per env/tenant at build
+ * time.
  *
  * Solution: This plugin runs before `define` (`enforce: 'pre'`) and rewrites
  * `process.env.XXX` → `globalThis.__MFE_ENV__["XXX"]`. Dynamic property access
- * cannot be constant-folded, so all tokens stay inside the `mfe-configs` chunk
- * where `tokenReplacement.sh` can find them.
+ * cannot be constant-folded, so every config read resolves through a single
+ * `globalThis.__MFE_ENV__` object at runtime, keeping application chunk bytes
+ * independent of which env's values are in play.
+ *
+ * The `globalThis.__MFE_ENV__` object itself is initialised by
+ * `multiEnvConfigEmitter` (04-gdu-vite8.md §2.3, lands in PR13 / AG-20099),
+ * which emits one config chunk per env×tenant combo. This plugin owns only the
+ * key-name rewrite; it no longer bakes an init block into the `mfe-configs`
+ * chunk.
  */
 export function mfeEnvTokens(envTokens: Record<string, string>): VitePlugin {
 	const keys = Object.keys(envTokens);
@@ -28,11 +36,6 @@ export function mfeEnvTokens(envTokens: Record<string, string>): VitePlugin {
 		'g',
 	);
 
-	const initEntries = keys
-		.map((key) => `${JSON.stringify(key)}:${envTokens[key]}`)
-		.join(',');
-	const initCode = `globalThis.__MFE_ENV__={${initEntries}};`;
-
 	return {
 		name: 'gdu-mfe-env-tokens',
 		apply: 'build',
@@ -47,11 +50,6 @@ export function mfeEnvTokens(envTokens: Record<string, string>): VitePlugin {
 			);
 
 			return result === code ? null : { code: result, map: null };
-		},
-
-		renderChunk(code, chunk) {
-			if (!chunk.fileName.includes('mfe-configs')) return null;
-			return { code: initCode + code, map: null };
 		},
 	};
 }

--- a/packages/gdu/config/vite/plugins/multiEnvConfigEmitter.ts
+++ b/packages/gdu/config/vite/plugins/multiEnvConfigEmitter.ts
@@ -1,0 +1,87 @@
+import { createHash } from 'crypto';
+
+import {
+	mergeConfigSources,
+	resolveCombosForApp,
+} from '../../../lib/mfeDataReader';
+import type { PluginContext, VitePlugin } from '../types';
+
+interface MultiEnvConfigEmitterOptions {
+	appName: string;
+	workspaceRoot: string;
+	envTokenMap: Record<string, string>;
+}
+
+/**
+ * Emits one init-only `mfe-configs-<env>_<tenant>-<hash>.js` script per
+ * env×tenant combo the app targets, each a standalone
+ * `globalThis.__MFE_ENV__={...}` assignment carrying that combo's real, resolved
+ * config values. The host injects the combo's script ahead of the app bundle so
+ * `globalThis.__MFE_ENV__` is defined before any config read runs (00-overview
+ * §4c; 05 host read side).
+ *
+ * The `mfe-configs` chunk itself is left untouched — `mfeEnvTokens` (enforce:
+ * 'pre') has already rewritten its `process.env.X` reads to
+ * `globalThis.__MFE_ENV__.X`, so it is env-agnostic (identical bytes for every
+ * combo) and, crucially, still exports the config bindings that the rest of the
+ * app graph imports. Only the tiny init scripts differ per combo, so one build
+ * pass yields one env-agnostic app bundle plus N small config scripts whose
+ * bytes depend solely on that combo's values. `guruBuildManifest` records the
+ * emitted scripts in its `env` map.
+ *
+ * Config values are restricted to the keys the app actually reads (the
+ * `envTokenMap` keys `mfeEnvTokens` rewrites), keeping CDK-only infra keys out
+ * of the browser bundle and guaranteeing every rewritten read resolves.
+ */
+export function multiEnvConfigEmitter(
+	opts: MultiEnvConfigEmitterOptions,
+): VitePlugin {
+	const allowKeys = Object.keys(opts.envTokenMap);
+
+	return {
+		name: 'gdu-multi-env-config-emitter',
+		apply: 'build',
+
+		generateBundle(this: PluginContext, _options, bundle) {
+			const hasConfigChunk = Object.keys(bundle).some((fileName) =>
+				/^mfe-configs-[a-zA-Z\d]+\.js$/.test(fileName),
+			);
+			if (!hasConfigChunk) return;
+
+			const combos = resolveCombosForApp(
+				opts.appName,
+				opts.workspaceRoot,
+			);
+
+			if (combos.length === 0) {
+				console.warn(
+					`gdu-multi-env-config-emitter: no env×tenant combos found for ` +
+						`"${opts.appName}" in .mfe-data/mfe-list.json — no config ` +
+						`scripts emitted; globalThis.__MFE_ENV__ will be uninitialised.`,
+				);
+				return;
+			}
+
+			for (const { env, tenant } of combos) {
+				const values = mergeConfigSources(
+					opts.workspaceRoot,
+					opts.appName,
+					env,
+					tenant,
+					allowKeys,
+				);
+				const source = `globalThis.__MFE_ENV__=${JSON.stringify(values)};`;
+				const hash = createHash('sha256')
+					.update(source)
+					.digest('hex')
+					.slice(0, 8);
+
+				this.emitFile({
+					type: 'asset',
+					fileName: `mfe-configs-${env}_${tenant}-${hash}.js`,
+					source,
+				});
+			}
+		},
+	};
+}

--- a/packages/gdu/config/vite/vite.config.ts
+++ b/packages/gdu/config/vite/vite.config.ts
@@ -4,12 +4,13 @@ import path, { join, resolve } from 'path';
 import envCI from 'env-ci';
 
 import { getGuruConfig, getProjectName } from '../../lib/config';
-import { GDU_ROOT, PROJECT_ROOT } from '../../lib/roots';
+import { CALLING_WORKSPACE_ROOT, GDU_ROOT, PROJECT_ROOT } from '../../lib/roots';
 import { getBuildEnvs, getConfigsDirs } from '../../utils/configs';
 import { getExternals } from '../shared/externals';
 
 import { guruBuildManifest } from './plugins/GuruBuildManifest';
 import { mfeEnvTokens } from './plugins/mfeEnvTokens';
+import { multiEnvConfigEmitter } from './plugins/multiEnvConfigEmitter';
 import { overdriveBarrelSplit } from './plugins/overdriveBarrelSplit';
 import { rolldownExternalShim } from './plugins/rolldownExternalShim';
 import { runtimePublicPath } from './plugins/runtimePublicPath';
@@ -207,6 +208,11 @@ export const baseViteOptions = ({
 			// injected by buildSPA-vite.ts and runSPA-vite.ts to avoid tsc dependency on vite.
 			overdriveBarrelSplit(),
 			mfeEnvTokens(envTokenMap),
+			multiEnvConfigEmitter({
+				appName: getProjectName(),
+				workspaceRoot: CALLING_WORKSPACE_ROOT ?? PROJECT_ROOT,
+				envTokenMap,
+			}),
 			rolldownExternalShim(externalsMap),
 			guruBuildManifest({
 				mountDOMId: guruConfig.mountDOMId,

--- a/packages/gdu/config/vite/vite.config.ts
+++ b/packages/gdu/config/vite/vite.config.ts
@@ -137,9 +137,11 @@ export const baseViteOptions = ({
 			__GDU_APP_NAME__: JSON.stringify(getProjectName()),
 			__GDU_BUILD_INFO__: JSON.stringify({ commit, branch }),
 			// In production builds, mfeEnvTokens (enforce: 'pre') rewrites
-			// process.env.X to globalThis.__MFE_ENV__[X] before `define` runs,
-			// so these entries only take effect in dev mode where the plugin
-			// is disabled (apply: 'build').
+			// process.env.X to globalThis.__MFE_ENV__["X"] before `define` runs
+			// (the __MFE_ENV__ object is emitted as a separate per-env/tenant
+			// config chunk by multiEnvConfigEmitter, PR13 / AG-20099), so these
+			// entries only take effect in dev mode where the plugin is disabled
+			// (apply: 'build').
 			...envDefines,
 		},
 

--- a/packages/gdu/lib/__tests__/mfeDataReader.test.ts
+++ b/packages/gdu/lib/__tests__/mfeDataReader.test.ts
@@ -1,0 +1,203 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+	mergeConfigSources,
+	resolveCombosForApp,
+	toBareAppName,
+} from '../mfeDataReader';
+
+interface FixtureShape {
+	mfeList?: unknown;
+	envConfigs?: Record<string, Record<string, unknown>>;
+	appConfigs?: Record<string, Record<string, Record<string, unknown>>>;
+}
+
+function writeFixture(fixture: FixtureShape): string {
+	const root = mkdtempSync(join(tmpdir(), 'mfe-data-'));
+	const dataRoot = join(root, '.mfe-data');
+	mkdirSync(dataRoot, { recursive: true });
+
+	if (fixture.mfeList !== undefined) {
+		writeFileSync(
+			join(dataRoot, 'mfe-list.json'),
+			JSON.stringify(fixture.mfeList),
+		);
+	}
+
+	for (const [combo, values] of Object.entries(fixture.envConfigs ?? {})) {
+		mkdirSync(join(dataRoot, 'env-configs'), { recursive: true });
+		writeFileSync(
+			join(dataRoot, 'env-configs', `${combo}.json`),
+			JSON.stringify(values),
+		);
+	}
+
+	for (const [app, combos] of Object.entries(fixture.appConfigs ?? {})) {
+		const appDir = join(dataRoot, 'app-configs', app);
+		mkdirSync(appDir, { recursive: true });
+		for (const [combo, values] of Object.entries(combos)) {
+			writeFileSync(
+				join(appDir, `${combo}.json`),
+				JSON.stringify(values),
+			);
+		}
+	}
+
+	return root;
+}
+
+describe('toBareAppName', () => {
+	it('strips the @autoguru/ scope', () => {
+		expect(toBareAppName('@autoguru/fls-booking')).toBe('fls-booking');
+	});
+
+	it('leaves an already-bare name unchanged', () => {
+		expect(toBareAppName('fls-booking')).toBe('fls-booking');
+	});
+});
+
+describe('resolveCombosForApp', () => {
+	let root: string;
+	afterEach(() => {
+		if (root) rmSync(root, { recursive: true, force: true });
+	});
+
+	it('flattens the modal au-full + nz-three shape into 8 combos', () => {
+		root = writeFixture({
+			mfeList: {
+				spa: {
+					'fls-booking': {
+						au: ['dev', 'uat', 'test', 'preprod', 'prod'],
+						nz: ['dev', 'preprod', 'prod'],
+					},
+				},
+			},
+		});
+
+		expect(resolveCombosForApp('@autoguru/fls-booking', root)).toEqual([
+			{ env: 'dev', tenant: 'au' },
+			{ env: 'uat', tenant: 'au' },
+			{ env: 'test', tenant: 'au' },
+			{ env: 'preprod', tenant: 'au' },
+			{ env: 'prod', tenant: 'au' },
+			{ env: 'dev', tenant: 'nz' },
+			{ env: 'preprod', tenant: 'nz' },
+			{ env: 'prod', tenant: 'nz' },
+		]);
+	});
+
+	it('resolves an NZ-only outlier to NZ combos only', () => {
+		root = writeFixture({
+			mfeList: { spa: { 'nz-only-app': { nz: ['dev', 'prod'] } } },
+		});
+
+		expect(resolveCombosForApp('nz-only-app', root)).toEqual([
+			{ env: 'dev', tenant: 'nz' },
+			{ env: 'prod', tenant: 'nz' },
+		]);
+	});
+
+	it('resolves an AU+NZ-full outlier across both tenants', () => {
+		root = writeFixture({
+			mfeList: {
+				spa: {
+					'both-full': {
+						au: ['dev', 'prod'],
+						nz: ['dev', 'prod'],
+					},
+				},
+			},
+		});
+
+		expect(resolveCombosForApp('both-full', root)).toEqual([
+			{ env: 'dev', tenant: 'au' },
+			{ env: 'prod', tenant: 'au' },
+			{ env: 'dev', tenant: 'nz' },
+			{ env: 'prod', tenant: 'nz' },
+		]);
+	});
+
+	it('yields no combos for a global-only app with no au/nz keys', () => {
+		root = writeFixture({
+			mfeList: { spa: { 'global-app': { global: ['shared'] } } },
+		});
+
+		expect(resolveCombosForApp('global-app', root)).toEqual([]);
+	});
+
+	it('yields no combos for an app absent from the list', () => {
+		root = writeFixture({ mfeList: { spa: {} } });
+		expect(resolveCombosForApp('missing-app', root)).toEqual([]);
+	});
+
+	it('yields no combos when the list is missing entirely', () => {
+		root = writeFixture({});
+		expect(resolveCombosForApp('any-app', root)).toEqual([]);
+	});
+});
+
+describe('mergeConfigSources', () => {
+	let root: string;
+	afterEach(() => {
+		if (root) rmSync(root, { recursive: true, force: true });
+	});
+
+	it('lets app-configs override env-configs (later wins)', () => {
+		root = writeFixture({
+			envConfigs: {
+				dev_au: { baseUrl: 'https://env', shared: 'from-env' },
+			},
+			appConfigs: {
+				'fls-booking': { dev_au: { shared: 'from-app' } },
+			},
+		});
+
+		expect(
+			mergeConfigSources(root, 'fls-booking', 'dev', 'au'),
+		).toEqual({ baseUrl: 'https://env', shared: 'from-app' });
+	});
+
+	it('restricts the result to the allowlisted keys', () => {
+		root = writeFixture({
+			envConfigs: {
+				dev_au: {
+					baseUrl: 'https://env',
+					cdkOnly: 'should-not-ship',
+				},
+			},
+		});
+
+		expect(
+			mergeConfigSources(root, 'fls-booking', 'dev', 'au', [
+				'baseUrl',
+			]),
+		).toEqual({ baseUrl: 'https://env' });
+	});
+
+	it('returns an empty object when both sources are missing', () => {
+		root = writeFixture({});
+		expect(
+			mergeConfigSources(root, 'fls-booking', 'dev', 'au'),
+		).toEqual({});
+	});
+
+	it('strips the scope before locating app-configs', () => {
+		root = writeFixture({
+			envConfigs: { prod_nz: { baseUrl: 'https://env' } },
+			appConfigs: {
+				'fls-booking': { prod_nz: { baseUrl: 'https://app' } },
+			},
+		});
+
+		expect(
+			mergeConfigSources(
+				root,
+				'@autoguru/fls-booking',
+				'prod',
+				'nz',
+			),
+		).toEqual({ baseUrl: 'https://app' });
+	});
+});

--- a/packages/gdu/lib/mfeDataReader.ts
+++ b/packages/gdu/lib/mfeDataReader.ts
@@ -1,0 +1,97 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+export interface EnvTenantCombo {
+	env: string;
+	tenant: 'au' | 'nz';
+}
+
+const TENANTS: ReadonlyArray<'au' | 'nz'> = ['au', 'nz'];
+
+/**
+ * Strips the `@autoguru/` scope so a scoped package name (`getProjectName()`)
+ * matches the bare keys used in `.mfe-data/mfe-list.json`.
+ */
+export function toBareAppName(appName: string): string {
+	return appName.replace(/^@autoguru\//, '');
+}
+
+function readJson(filePath: string): Record<string, unknown> | null {
+	if (!existsSync(filePath)) return null;
+	try {
+		return JSON.parse(readFileSync(filePath, 'utf8'));
+	} catch (error) {
+		// A malformed committed config must surface at build time — an absent
+		// file is legitimate (returns null quietly above), but a parse failure
+		// would otherwise silently bake an empty __MFE_ENV__.
+		console.warn(`[mfeDataReader] Failed to parse ${filePath}:`, error);
+		return null;
+	}
+}
+
+/**
+ * Resolves the env×tenant combos an SPA targets from `.mfe-data/mfe-list.json`
+ * (keyed `type → app → {au|nz: [envs]}`). Reads the matrix per app — never
+ * hardcodes it — so outliers (NZ-only, AU+NZ-full, global/shared-only) resolve
+ * to exactly what the list declares. An app with no `au`/`nz` keys (e.g. the
+ * global-only `mfe-manager`) yields no combos and emits no config chunks.
+ */
+export function resolveCombosForApp(
+	appName: string,
+	workspaceRoot: string,
+): EnvTenantCombo[] {
+	const bareName = toBareAppName(appName);
+	const mfeList = readJson(join(workspaceRoot, '.mfe-data', 'mfe-list.json'));
+	const spaEntry = (mfeList?.spa as Record<string, unknown> | undefined)?.[
+		bareName
+	] as Record<string, unknown> | undefined;
+
+	if (!spaEntry) return [];
+
+	const combos: EnvTenantCombo[] = [];
+	for (const tenant of TENANTS) {
+		const envs = spaEntry[tenant];
+		if (!Array.isArray(envs)) continue;
+		for (const env of envs) {
+			if (typeof env === 'string') combos.push({ env, tenant });
+		}
+	}
+	return combos;
+}
+
+/**
+ * Merges the real per-env/tenant config values a build bakes into
+ * `globalThis.__MFE_ENV__` for one combo, in precedence order (later wins):
+ * `.mfe-data/env-configs/{env}_{tenant}.json` (global config values) then
+ * `.mfe-data/app-configs/<app>/{env}_{tenant}.json` (app infra overrides).
+ *
+ * When `allowKeys` is supplied the result is restricted to those keys — the
+ * set the application actually reads (the `process.env.*` tokens rewritten by
+ * `mfeEnvTokens`). This keeps CDK-only infra keys out of the browser bundle and
+ * guarantees every rewritten read resolves to a value.
+ */
+export function mergeConfigSources(
+	workspaceRoot: string,
+	appName: string,
+	env: string,
+	tenant: string,
+	allowKeys?: ReadonlyArray<string>,
+): Record<string, unknown> {
+	const bareName = toBareAppName(appName);
+	const dataRoot = join(workspaceRoot, '.mfe-data');
+	const combo = `${env}_${tenant}.json`;
+
+	const merged: Record<string, unknown> = {
+		...readJson(join(dataRoot, 'env-configs', combo)),
+		...readJson(join(dataRoot, 'app-configs', bareName, combo)),
+	};
+
+	if (!allowKeys) return merged;
+
+	const allow = new Set(allowKeys);
+	const filtered: Record<string, unknown> = {};
+	for (const key of Object.keys(merged)) {
+		if (allow.has(key)) filtered[key] = merged[key];
+	}
+	return filtered;
+}

--- a/packages/gdu/package.json
+++ b/packages/gdu/package.json
@@ -88,7 +88,7 @@
 		"ts-node": "^9.0.0",
 		"tsconfig-paths-webpack-plugin": "^3.5.2",
 		"url-loader": "^4.1.1",
-		"vite": "^8.0.0-beta.0",
+		"vite": "^8.1.3",
 		"vite-tsconfig-paths": "^5.1.0",
 		"webpack": "5.96.1",
 		"webpack-dev-server": "^5.2.0",


### PR DESCRIPTION
## What

UD PR13 (AG-20099). Emits real per-env/tenant SPA config and the multi-env `build-manifest.json`, closing the `__MFE_ENV__` window PR12 opened. **Stacked on `feat/AG-20098-gdu-vite-8`** (retarget to `main` after PR12 merges).

- **`multiEnvConfigEmitter`** (`generateBundle` hook): for each env×tenant combo an SPA targets (read per-app from `.mfe-data/mfe-list.json`), emits one init-only `mfe-configs-<env>_<tenant>-<hash>.js` script — a standalone `globalThis.__MFE_ENV__={...}` carrying that combo's real, resolved values (merged `.mfe-data/env-configs` + `.mfe-data/app-configs`, app wins), restricted to the keys the app actually reads.
- **`guruBuildManifest`**: records the scripts in an `env` map (`env[<env>_<tenant>].config`) per `00-overview.md` §4c.
- **`mfeDataReader`**: shared `resolveCombosForApp` + `mergeConfigSources`.
- Golden-manifest test byte-matches the §4c env-map shape; full unit coverage for the reader (incl. the three §4g outliers), the emitter, and the manifest classifier.

## Two deliberate divergences from 04 §2.3 (both validated in a real browser)

1. **Init-only scripts + intact `mfe-configs` chunk** (04 §2.3 said emit `init + chunk code` and empty the original chunk to a `{code:''}` stub). Emptying the chunk **breaks the module graph** — other app chunks `import` the config bindings from it (`SyntaxError: ... does not provide an export named 'E'`, caught in the browser test). The `mfe-configs` chunk is already env-agnostic (its `process.env.X` reads were rewritten to `globalThis.__MFE_ENV__.X` by PR12's `mfeEnvTokens`), so it is left intact and only tiny init-only scripts are emitted per combo.
2. **Allowlist by `envTokenMap` keys**, not 04 gotcha 9's global-configs cross-reference. `.mfe-data` keys are camelCase while `packages/global-configs` files are SCREAMING_SNAKE; importing consumer-repo code into the toolkit is the fragile drift 04 §6 itself flags. `envTokenMap` is the exact in-process app-read set and guarantees every rewritten read resolves.

Both are flagged for a 04 doc update (the doc's §2.3 stub approach and §2.4 empty-stub-skip are superseded).

## Schema note

The emitted `env[<combo>].config` value is the **bare** filename (e.g. `mfe-configs-dev_au-a348c932.js`), consistent with how `assets`/`chunks` are emitted; the host/Lambda prepends the versioned CDN path at runtime. `00-overview.md` §4c's example shows the prefixed post-deploy form — illustrative, not the emission shape (flagged for the docs follow-up).

## Validation — Workflow A (`08-validation-workflows.md` §2), pilot `fls-booking`

GDU built from this branch, linked into the mfe checkout, then restored to registry `13.20.1` (zero diff left in mfe).

| Step | Result |
|---|---|
| Prod build (dev_au) | Pass — `build-manifest.json` `env` map carries **exactly the 8 fls-booking combos** (`au: dev/uat/test/preprod/prod` + `nz: dev/preprod/prod`), sorted, bare filenames; 8 `mfe-configs-<combo>-<hash>.js` scripts emitted |
| Per-combo values | Pass — `dev_au.baseUrl = https://www.au-dev.autoguru.com` vs `prod_au.baseUrl = https://www.autoguru.com.au`; no `#{TOKEN}` placeholders; init-only scripts (no chunk body); CDK-only keys excluded by the allowlist |
| App chunk intact | Pass — `mfe-configs-<hash>.js` app chunk keeps its exports (1606 bytes, `export{…}`), stable env-agnostic hash; excluded from the `env` map |
| Prod-serve render (dev_au) | **Pass — `globalThis.__MFE_ENV__` defined from the injected script (47 keys, real dev_au values), app boots and mounts, ZERO console errors** — the PR12 `TypeError` gap is closed |
| Prod-serve render (dev_nz) | **Pass — `__MFE_ENV__.baseUrl = https://www.nz-dev.autoguru.com` (correct NZ values, no cross-tenant bleed), ZERO console errors** |

*Host-injection note:* the config now lives in separate init scripts (not the module graph), so the **host must inject** `env[<combo>].config` ahead of the app bundle. The stock `mfe-local-prod-server.js` does not yet do this (it only loads `assets.js` and mocks `window.__globalConfigs`); the render evidence above used a scratchpad server that performs the injection, mirroring the PR14/05 host read-side. **Teaching the real local prod server + app-shell to read the `env` map is PR14/05 host-side work** — flagged, out of this octane PR's scope.

## Out of scope

`sourcemap: 'hidden'` (04 §2.7) is unchanged and unaffected — the init scripts have no sourcemaps and don't touch the app bundle's maps. `sp-global-notification`/fleet Vite migration and the host read-side (PR14) remain out of scope.

## Known unrelated CI failure

`packages/browserslist-config/test.spec.js` fails a snapshot (date-driven `caniuse-lite` drift; identical to PR12's note). Not touched by this PR; handled in a separate hygiene PR.
