### PR TITLE
feat(AG-20165): compat mode — old single-env config contract as safe default

### DIFF
--- a/.changeset/AG-20165-gdu-compat-mode.md
+++ b/.changeset/AG-20165-gdu-compat-mode.md
@@ -1,0 +1,28 @@
+---
+'gdu': minor
+---
+
+feat(AG-20165): compat mode — old single-env config contract as safe default
+
+Restore the single-env config contract as the default build behaviour, with
+multi-env emission now gated behind the `GDU_MULTI_ENV_CONFIG` env var.
+
+Since 13.21.0 the SPA build unconditionally dropped the baked
+`globalThis.__MFE_ENV__={...#{TOKEN}...}` init block (PR #439) and always
+emitted per-combo config scripts plus a manifest `env` map (PR #441). An app
+rebuilt under 13.21.0 therefore stopped producing the artefact the old host and
+the 6 old pipelines expect — the `mfe-configs` chunk read
+`globalThis.__MFE_ENV__` without anything ever assigning it, crashing on the
+first config read.
+
+The default (`GDU_MULTI_ENV_CONFIG` unset) now restores that contract byte-for-
+byte at the chunk level: `mfeEnvTokens` again prepends the init block to the
+`mfe-configs` chunk via a `bakeInitBlock` option, `multiEnvConfigEmitter` is
+omitted from the plugin list, and the manifest carries no `env` key. Setting
+`GDU_MULTI_ENV_CONFIG=1` opts into the 13.21.0 behaviour unchanged. The
+`process.env.X` → `globalThis.__MFE_ENV__["X"]` key rewrite runs in both modes.
+
+The env var is read once at the `config/vite/index.ts` seam and threaded through
+`baseViteOptions`/`makeViteConfig` as a plain boolean, so both modes are
+unit-testable without env mutation. This is transitional — once every SPA is
+migrated the gate and the restored bake can be dropped.

--- a/packages/gdu/commands/start/runSPA-vite.ts
+++ b/packages/gdu/commands/start/runSPA-vite.ts
@@ -224,6 +224,7 @@ export const runSPAVite = async (guruConfig: GuruConfig, isDebug: boolean) => {
 		buildEnv: appEnv,
 		isMultiEnv: false,
 		standalone: guruConfig?.standalone,
+		multiEnvConfig: false,
 	}) as Record<string, any>;
 
 	const { createServer } = (await dynamicImport('vite')) as {

--- a/packages/gdu/config/vite/__tests__/vite.config.test.ts
+++ b/packages/gdu/config/vite/__tests__/vite.config.test.ts
@@ -1,0 +1,102 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { getConfigsDirs } from '../../../utils/configs';
+import { baseViteOptions } from '../vite.config';
+
+jest.mock('../../../lib/config', () => ({
+	getGuruConfig: jest.fn(() => ({
+		outputPath: '/workspace/out',
+		mountDOMId: 'root',
+		mountDOMClass: 'cls',
+		frameless: false,
+		standalone: false,
+	})),
+	getProjectName: jest.fn(() => 'test-app'),
+}));
+
+jest.mock('../../shared/externals', () => ({
+	getExternals: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../lib/roots', () => ({
+	PROJECT_ROOT: '/workspace/proj/',
+	GDU_ROOT: '/workspace/gdu/',
+	CALLING_WORKSPACE_ROOT: '/workspace/ws/',
+}));
+
+jest.mock('../../../utils/configs', () => ({
+	getBuildEnvs: jest.fn(() => ['dev_au']),
+	getConfigsDirs: jest.fn(() => []),
+}));
+
+const EMITTER = 'gdu-multi-env-config-emitter';
+const ENV_TOKENS = 'gdu-mfe-env-tokens';
+
+type NamedPlugin = { name: string; renderChunk?: unknown };
+
+function configFor(
+	multiEnvConfig: boolean,
+): ReturnType<typeof baseViteOptions> {
+	return baseViteOptions({
+		buildEnv: 'dev_au',
+		isMultiEnv: false,
+		standalone: false,
+		multiEnvConfig,
+	});
+}
+
+function pluginNames(config: ReturnType<typeof baseViteOptions>): string[] {
+	return ((config.plugins ?? []) as NamedPlugin[]).map((p) => p.name);
+}
+
+function findPlugin(
+	config: ReturnType<typeof baseViteOptions>,
+	name: string,
+): NamedPlugin | undefined {
+	return ((config.plugins ?? []) as NamedPlugin[]).find(
+		(p) => p.name === name,
+	);
+}
+
+let configsDir: string;
+
+beforeAll(() => {
+	// A single .env.defaults token guarantees mfeEnvTokens is a live plugin
+	// (not the empty no-op), so its renderChunk presence reflects bakeInitBlock.
+	configsDir = mkdtempSync(join(tmpdir(), 'gdu-vite-config-'));
+	writeFileSync(
+		join(configsDir, '.env.defaults'),
+		'IS_PRODUCTION="#{IS_PRODUCTION}"\n',
+	);
+	(getConfigsDirs as jest.Mock).mockReturnValue([configsDir]);
+});
+
+afterAll(() => {
+	if (configsDir) rmSync(configsDir, { recursive: true, force: true });
+});
+
+describe('baseViteOptions plugin selection', () => {
+	describe('when multiEnvConfig is false (single-env default)', () => {
+		it('omits the multi-env config emitter from the plugin list', () => {
+			expect(pluginNames(configFor(false))).not.toContain(EMITTER);
+		});
+
+		it('constructs mfeEnvTokens with the init-block bake enabled', () => {
+			const plugin = findPlugin(configFor(false), ENV_TOKENS);
+			expect(plugin).toHaveProperty('renderChunk');
+		});
+	});
+
+	describe('when multiEnvConfig is true (multi-env opt-in)', () => {
+		it('includes the multi-env config emitter in the plugin list', () => {
+			expect(pluginNames(configFor(true))).toContain(EMITTER);
+		});
+
+		it('constructs mfeEnvTokens without the init-block bake', () => {
+			const plugin = findPlugin(configFor(true), ENV_TOKENS);
+			expect(plugin).not.toHaveProperty('renderChunk');
+		});
+	});
+});

--- a/packages/gdu/config/vite/index.ts
+++ b/packages/gdu/config/vite/index.ts
@@ -10,6 +10,19 @@ export interface ViteConfigOpts {
 	standalone?: boolean;
 }
 
+/**
+ * Multi-env config emission is opt-in per build via `GDU_MULTI_ENV_CONFIG`.
+ * When unset (the default) the build restores the single-env contract: the
+ * `mfe-configs` chunk carries a baked `globalThis.__MFE_ENV__={...#{TOKEN}...}`
+ * init block and no per-combo scripts or manifest `env` map are emitted
+ * (04-gdu-vite8.md §2.8). This is the single env-read site — the config
+ * functions take a plain boolean so both modes are unit-testable without env
+ * mutation.
+ */
+const multiEnvConfig = ['1', 'true'].includes(
+	(process.env.GDU_MULTI_ENV_CONFIG ?? '').toLowerCase(),
+);
+
 export default (options: ViteConfigOpts): InlineConfig[] => {
 	const { env = process.env.APP_ENV, standalone } = options;
 	const isProduction = isProductionBuild();
@@ -18,7 +31,7 @@ export default (options: ViteConfigOpts): InlineConfig[] => {
 	if (isProduction) {
 		const isMultiEnv = buildEnvs.length > 1;
 		return buildEnvs.map((buildEnv) =>
-			makeViteConfig(buildEnv, isMultiEnv, standalone),
+			makeViteConfig(buildEnv, isMultiEnv, standalone, multiEnvConfig),
 		) as InlineConfig[];
 	} else {
 		const buildEnv = env || 'dev_au';
@@ -28,6 +41,7 @@ export default (options: ViteConfigOpts): InlineConfig[] => {
 				buildEnv,
 				isMultiEnv: false,
 				standalone,
+				multiEnvConfig,
 			}),
 		] as InlineConfig[];
 	}

--- a/packages/gdu/config/vite/plugins/__tests__/GuruBuildManifest.test.ts
+++ b/packages/gdu/config/vite/plugins/__tests__/GuruBuildManifest.test.ts
@@ -1,6 +1,11 @@
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
 import {
 	collectEntryCssFiles,
 	collectEnvConfigChunks,
+	guruBuildManifest,
 } from '../GuruBuildManifest';
 
 type BundleChunk = {
@@ -283,5 +288,59 @@ describe('collectEnvConfigChunks', () => {
 		expect(env.dev_au.config).toBe(
 			'https://cdn/app/v1/mfe-configs-dev_au-1a2b3c4d.js',
 		);
+	});
+});
+
+describe('guruBuildManifest env map', () => {
+	type ManifestChunk = {
+		type: string;
+		isEntry?: boolean;
+		source?: string;
+		viteMetadata?: { importedCss?: Set<string> };
+	};
+
+	const tempDirs: string[] = [];
+	afterAll(() => {
+		for (const dir of tempDirs)
+			rmSync(dir, { recursive: true, force: true });
+	});
+
+	function writeManifest(bundle: Record<string, ManifestChunk>): {
+		env?: Record<string, { config: string }>;
+	} {
+		const outputDir = mkdtempSync(join(tmpdir(), 'gdu-manifest-'));
+		tempDirs.push(outputDir);
+		const plugin = guruBuildManifest({
+			mountDOMId: 'root',
+			mountDOMClass: 'cls',
+			frameless: false,
+			outputDir,
+			includeChunks: true,
+		});
+		plugin.writeBundle?.({ dir: outputDir }, bundle as never);
+		return JSON.parse(
+			readFileSync(join(outputDir, 'build-manifest.json'), 'utf8'),
+		);
+	}
+
+	it('omits the env key when no per-combo config assets are emitted (single-env default)', () => {
+		const manifest = writeManifest({
+			'main-ab12cd34.js': { type: 'chunk', isEntry: true },
+			'mfe-configs-1a2b3c4d.js': { type: 'chunk', isEntry: false },
+		});
+
+		expect(manifest.env).toBeUndefined();
+	});
+
+	it('populates the env map when per-combo config assets are present (multi-env opt-in)', () => {
+		const manifest = writeManifest({
+			'main-ab12cd34.js': { type: 'chunk', isEntry: true },
+			'mfe-configs-1a2b3c4d.js': { type: 'chunk', isEntry: false },
+			'mfe-configs-dev_au-3c4d5e6f.js': { type: 'asset' },
+		});
+
+		expect(manifest.env).toEqual({
+			dev_au: { config: 'mfe-configs-dev_au-3c4d5e6f.js' },
+		});
 	});
 });

--- a/packages/gdu/config/vite/plugins/__tests__/mfeEnvTokens.test.ts
+++ b/packages/gdu/config/vite/plugins/__tests__/mfeEnvTokens.test.ts
@@ -1,6 +1,10 @@
 import { mfeEnvTokens } from '../mfeEnvTokens';
 
 type TransformFn = (code: string) => { code: string; map: null } | null;
+type RenderChunkFn = (
+	code: string,
+	chunk: { fileName: string },
+) => { code: string; map: null } | null;
 
 function getTransform(plugin: ReturnType<typeof mfeEnvTokens>): TransformFn {
 	const hook = plugin.transform;
@@ -8,6 +12,16 @@ function getTransform(plugin: ReturnType<typeof mfeEnvTokens>): TransformFn {
 		return hook.bind(null) as unknown as TransformFn;
 	}
 	throw new Error('expected transform to be a function hook');
+}
+
+function getRenderChunk(
+	plugin: ReturnType<typeof mfeEnvTokens>,
+): RenderChunkFn {
+	const hook = plugin.renderChunk;
+	if (typeof hook === 'function') {
+		return hook.bind(null) as unknown as RenderChunkFn;
+	}
+	throw new Error('expected renderChunk to be a function hook');
 }
 
 const envTokens = {
@@ -77,9 +91,75 @@ describe('mfeEnvTokens', () => {
 
 			expect(transform('const a = 1;')).toBeNull();
 		});
+	});
 
-		it('does not bake an init block into any chunk (owned by multiEnvConfigEmitter)', () => {
+	describe('when bakeInitBlock is true (single-env default)', () => {
+		// The exact bytes the old host + 6 old pipelines expect at the head of
+		// the mfe-configs chunk: a globalThis.__MFE_ENV__ assignment carrying the
+		// app's #{TOKEN} placeholders for tokenReplacement.sh to substitute.
+		const expectedInitBlock =
+			'globalThis.__MFE_ENV__={"IS_PRODUCTION":"#{IS_PRODUCTION}","BASE_URL":"#{BASE_URL}"};';
+
+		it('prepends the exact init block to the mfe-configs chunk', () => {
+			const renderChunk = getRenderChunk(
+				mfeEnvTokens(envTokens, { bakeInitBlock: true }),
+			);
+
+			const result = renderChunk('const config = 1;', {
+				fileName: 'mfe-configs-1a2b3c4d.js',
+			});
+
+			expect(result).toEqual({
+				code: `${expectedInitBlock}const config = 1;`,
+				map: null,
+			});
+		});
+
+		it('leaves the chunk head byte-equal to the old single-env contract', () => {
+			const renderChunk = getRenderChunk(
+				mfeEnvTokens(envTokens, { bakeInitBlock: true }),
+			);
+
+			const result = renderChunk('const config = 1;', {
+				fileName: 'mfe-configs-1a2b3c4d.js',
+			});
+
+			expect(result?.code.startsWith(expectedInitBlock)).toBe(true);
+		});
+
+		it('does not bake into chunks other than mfe-configs', () => {
+			const renderChunk = getRenderChunk(
+				mfeEnvTokens(envTokens, { bakeInitBlock: true }),
+			);
+
+			expect(
+				renderChunk('const x = 1;', {
+					fileName: 'main-1a2b3c4d.js',
+				}),
+			).toBeNull();
+		});
+
+		it('does not bake into confusably named chunks under chunks/', () => {
+			const renderChunk = getRenderChunk(
+				mfeEnvTokens(envTokens, { bakeInitBlock: true }),
+			);
+
+			expect(
+				renderChunk('const x = 1;', {
+					fileName: 'chunks/mfe-configs-panel-1a2b3c4d.js',
+				}),
+			).toBeNull();
+		});
+
+		it('bakes by default when no options are passed (safe default)', () => {
 			const plugin = mfeEnvTokens(envTokens);
+			expect(plugin).toHaveProperty('renderChunk');
+		});
+	});
+
+	describe('when bakeInitBlock is false (multi-env opt-in)', () => {
+		it('does not bake an init block into any chunk (owned by multiEnvConfigEmitter)', () => {
+			const plugin = mfeEnvTokens(envTokens, { bakeInitBlock: false });
 			expect(plugin).not.toHaveProperty('renderChunk');
 		});
 	});

--- a/packages/gdu/config/vite/plugins/__tests__/multiEnvConfigEmitter.test.ts
+++ b/packages/gdu/config/vite/plugins/__tests__/multiEnvConfigEmitter.test.ts
@@ -57,9 +57,11 @@ function runGenerateBundle(
 	for (const key of bundleKeys) {
 		bundle[key] = { type: 'chunk', fileName: key };
 	}
-	(
-		plugin.generateBundle as unknown as (...a: unknown[]) => void
-	).call(ctx, {}, bundle);
+	(plugin.generateBundle as unknown as (...a: unknown[]) => void).call(
+		ctx,
+		{},
+		bundle,
+	);
 	return emitted;
 }
 
@@ -81,6 +83,19 @@ describe('multiEnvConfigEmitter', () => {
 		root = writeWorkspace();
 		const emitted = runGenerateBundle(makePlugin(root), [
 			CONFIG_CHUNK,
+			'main-abc12345.js',
+		]);
+
+		expect(emitted.map((a) => a.fileName).sort()).toEqual([
+			expect.stringMatching(/^mfe-configs-dev_au-[a-f0-9]{8}\.js$/),
+			expect.stringMatching(/^mfe-configs-dev_nz-[a-f0-9]{8}\.js$/),
+		]);
+	});
+
+	it('detects the config chunk when its base64url hash contains _ or -', () => {
+		root = writeWorkspace();
+		const emitted = runGenerateBundle(makePlugin(root), [
+			'mfe-configs-BRHYz_Ev.js',
 			'main-abc12345.js',
 		]);
 

--- a/packages/gdu/config/vite/plugins/mfeEnvTokens.ts
+++ b/packages/gdu/config/vite/plugins/mfeEnvTokens.ts
@@ -1,5 +1,18 @@
 import type { VitePlugin } from '../types';
 
+export interface MfeEnvTokensOptions {
+	/**
+	 * When true (the safe default), the plugin prepends a
+	 * `globalThis.__MFE_ENV__={...#{TOKEN}...}` init block to the `mfe-configs`
+	 * chunk — the single-env contract the old host + 6 old pipelines expect
+	 * (`tokenReplacement.sh`/`sed` substitute the `#{TOKEN}` placeholders at
+	 * deploy time). When false, no init block is baked and `globalThis.__MFE_ENV__`
+	 * is instead initialised by the per-combo scripts `multiEnvConfigEmitter`
+	 * emits (04-gdu-vite8.md §2.8).
+	 */
+	bakeInitBlock?: boolean;
+}
+
 /**
  * Rewrites `process.env.XXX` reads to `globalThis.__MFE_ENV__["XXX"]` so
  * per-env/tenant config can be injected as a separate chunk rather than
@@ -16,13 +29,18 @@ import type { VitePlugin } from '../types';
  * `globalThis.__MFE_ENV__` object at runtime, keeping application chunk bytes
  * independent of which env's values are in play.
  *
- * The `globalThis.__MFE_ENV__` object itself is initialised by
- * `multiEnvConfigEmitter` (04-gdu-vite8.md §2.3, lands in PR13 / AG-20099),
- * which emits one config chunk per env×tenant combo. This plugin owns only the
- * key-name rewrite; it no longer bakes an init block into the `mfe-configs`
- * chunk.
+ * How `globalThis.__MFE_ENV__` is initialised depends on the build mode
+ * (04-gdu-vite8.md §2.8). In the default single-env contract (`bakeInitBlock`
+ * true) the plugin's `renderChunk` prepends the init block to the `mfe-configs`
+ * chunk. In multi-env mode (`bakeInitBlock` false) `multiEnvConfigEmitter` emits
+ * one init-only script per env×tenant combo and the plugin owns only the
+ * key-name rewrite. The rewrite itself runs in both modes.
  */
-export function mfeEnvTokens(envTokens: Record<string, string>): VitePlugin {
+export function mfeEnvTokens(
+	envTokens: Record<string, string>,
+	options: MfeEnvTokensOptions = {},
+): VitePlugin {
+	const { bakeInitBlock = true } = options;
 	const keys = Object.keys(envTokens);
 	if (keys.length === 0) {
 		return { name: 'gdu-mfe-env-tokens' };
@@ -35,6 +53,11 @@ export function mfeEnvTokens(envTokens: Record<string, string>): VitePlugin {
 		`\\bprocess\\.env\\.(${escapedKeys.join('|')})\\b`,
 		'g',
 	);
+
+	const initEntries = keys
+		.map((key) => `${JSON.stringify(key)}:${envTokens[key]}`)
+		.join(',');
+	const initCode = `globalThis.__MFE_ENV__={${initEntries}};`;
 
 	return {
 		name: 'gdu-mfe-env-tokens',
@@ -51,5 +74,19 @@ export function mfeEnvTokens(envTokens: Record<string, string>): VitePlugin {
 
 			return result === code ? null : { code: result, map: null };
 		},
+
+		...(bakeInitBlock
+			? {
+					renderChunk(code, chunk) {
+						// Only the root-level app config chunk
+						// (`mfe-configs-<hash>.js`); every other chunk is emitted
+						// under `chunks/`, so an anchored match avoids baking into
+						// confusably named chunks (e.g. `chunks/mfe-configs-*`).
+						if (!chunk.fileName.startsWith('mfe-configs'))
+							return null;
+						return { code: initCode + code, map: null };
+					},
+				}
+			: {}),
 	};
 }

--- a/packages/gdu/config/vite/plugins/multiEnvConfigEmitter.ts
+++ b/packages/gdu/config/vite/plugins/multiEnvConfigEmitter.ts
@@ -44,7 +44,9 @@ export function multiEnvConfigEmitter(
 
 		generateBundle(this: PluginContext, _options, bundle) {
 			const hasConfigChunk = Object.keys(bundle).some((fileName) =>
-				/^mfe-configs-[a-zA-Z\d]+\.js$/.test(fileName),
+				// Rolldown's `[hash]` is base64url, so the app config chunk's
+				// hash can contain `_` or `-` (e.g. mfe-configs-BRHYz_Ev.js).
+				/^mfe-configs-[a-zA-Z\d_-]+\.js$/.test(fileName),
 			);
 			if (!hasConfigChunk) return;
 

--- a/packages/gdu/config/vite/vite.config.ts
+++ b/packages/gdu/config/vite/vite.config.ts
@@ -4,7 +4,11 @@ import path, { join, resolve } from 'path';
 import envCI from 'env-ci';
 
 import { getGuruConfig, getProjectName } from '../../lib/config';
-import { CALLING_WORKSPACE_ROOT, GDU_ROOT, PROJECT_ROOT } from '../../lib/roots';
+import {
+	CALLING_WORKSPACE_ROOT,
+	GDU_ROOT,
+	PROJECT_ROOT,
+} from '../../lib/roots';
 import { getBuildEnvs, getConfigsDirs } from '../../utils/configs';
 import { getExternals } from '../shared/externals';
 
@@ -104,10 +108,12 @@ export const baseViteOptions = ({
 	buildEnv,
 	isMultiEnv,
 	standalone,
+	multiEnvConfig,
 }: {
 	buildEnv: string;
 	isMultiEnv: boolean;
 	standalone?: boolean;
+	multiEnvConfig: boolean;
 }): InlineConfig => {
 	const guruConfig = getGuruConfig();
 	const externalsMap = getExternals({ standalone });
@@ -139,10 +145,11 @@ export const baseViteOptions = ({
 			__GDU_BUILD_INFO__: JSON.stringify({ commit, branch }),
 			// In production builds, mfeEnvTokens (enforce: 'pre') rewrites
 			// process.env.X to globalThis.__MFE_ENV__["X"] before `define` runs
-			// (the __MFE_ENV__ object is emitted as a separate per-env/tenant
-			// config chunk by multiEnvConfigEmitter, PR13 / AG-20099), so these
-			// entries only take effect in dev mode where the plugin is disabled
-			// (apply: 'build').
+			// (the __MFE_ENV__ object is initialised either by the baked init
+			// block in the single-env default or by multiEnvConfigEmitter's
+			// per-combo scripts when multiEnvConfig is set — 04-gdu-vite8.md
+			// §2.8), so these entries only take effect in dev mode where the
+			// plugin is disabled (apply: 'build').
 			...envDefines,
 		},
 
@@ -207,12 +214,17 @@ export const baseViteOptions = ({
 			// Runtime plugins (vanillaExtractPlugin, tsconfigPaths, relayPlugin) are
 			// injected by buildSPA-vite.ts and runSPA-vite.ts to avoid tsc dependency on vite.
 			overdriveBarrelSplit(),
-			mfeEnvTokens(envTokenMap),
-			multiEnvConfigEmitter({
-				appName: getProjectName(),
-				workspaceRoot: CALLING_WORKSPACE_ROOT ?? PROJECT_ROOT,
-				envTokenMap,
-			}),
+			mfeEnvTokens(envTokenMap, { bakeInitBlock: !multiEnvConfig }),
+			...(multiEnvConfig
+				? [
+						multiEnvConfigEmitter({
+							appName: getProjectName(),
+							workspaceRoot:
+								CALLING_WORKSPACE_ROOT ?? PROJECT_ROOT,
+							envTokenMap,
+						}),
+					]
+				: []),
 			rolldownExternalShim(externalsMap),
 			guruBuildManifest({
 				mountDOMId: guruConfig.mountDOMId,
@@ -233,14 +245,20 @@ type BuildEnv = ReturnType<typeof getBuildEnvs>[number];
 export const makeViteConfig = (
 	buildEnv: BuildEnv,
 	isMultiEnv: boolean,
-	standalone?: boolean,
+	standalone: boolean | undefined,
+	multiEnvConfig: boolean,
 ): InlineConfig => {
 	const guruConfig = getGuruConfig();
 	const { outputPath } = guruConfig;
 
 	const outDir = `${outputPath}/${!isMultiEnv && buildEnv === 'prod' ? '' : buildEnv}`;
 
-	const base = baseViteOptions({ buildEnv, isMultiEnv, standalone });
+	const base = baseViteOptions({
+		buildEnv,
+		isMultiEnv,
+		standalone,
+		multiEnvConfig,
+	});
 
 	// Add the runtimePublicPath plugin for dynamic chunk resolution.
 	// The manifest keeps bare filenames — the Lambda adds the CDN prefix.


### PR DESCRIPTION
## What

Restores the old single-env config contract as the safe **default** build behaviour and gates the multi-env config emission behind a single env var, `GDU_MULTI_ENV_CONFIG`.

Since 13.21.0 the SPA build unconditionally dropped the baked `globalThis.__MFE_ENV__={…#{TOKEN}…}` init block (#439) and always emitted per-combo config scripts plus a manifest `env` map (#441). An app rebuilt under that release no longer produces the artefact the old host and the 6 old pipelines expect — the `mfe-configs` chunk reads `globalThis.__MFE_ENV__` but nothing assigns it, so the first config read throws. This blocks the mfe `gdu` bump (UD PR14) until there is a safe default.

## How

One boolean, `multiEnvConfig`, read once from `GDU_MULTI_ENV_CONFIG` at the `config/vite/index.ts` seam and threaded through `baseViteOptions`/`makeViteConfig` alongside the existing params. The dev path (`runSPA-vite.ts`) hard-sets it false.

- **Default (`GDU_MULTI_ENV_CONFIG` unset):** `mfeEnvTokens(envTokenMap, { bakeInitBlock: true })` restores the exact `renderChunk` that #439 deleted — it prepends the `globalThis.__MFE_ENV__={…}` init block to the `mfe-configs` chunk. `multiEnvConfigEmitter` is omitted from the plugin list, so no per-combo scripts and no manifest `env` map are emitted. Byte-for-byte the old contract at the chunk level.
- **Opt-in (`GDU_MULTI_ENV_CONFIG=1`):** the 13.21.0 behaviour unchanged — `bakeInitBlock` false, emitter present.
- The `process.env.X` → `globalThis.__MFE_ENV__["X"]` key rewrite runs in **both** modes.

The env read happens once; the config functions take a plain boolean, so both modes are unit-testable without env mutation. This is transitional — once every SPA is migrated, the gate and the restored bake can both be dropped (tracked as a decommission-wave sibling, 07 §2.3).

Changeset: **minor** → `gdu@13.22.0`.

## Tests

`config/vite` Jest suites, all green:
- `mfeEnvTokens` — `bakeInitBlock` true prepends the exact init block to the `mfe-configs` chunk and returns null for other chunks; false bakes nothing; defaults to true when no options are passed.
- `vite.config` plugin selection — `multiEnvConfig` false omits `gdu-multi-env-config-emitter` and keeps `mfeEnvTokens`' `renderChunk`; true is the inverse.
- Golden test on the exact init-block bytes (`globalThis.__MFE_ENV__={"IS_PRODUCTION":"#{IS_PRODUCTION}","BASE_URL":"#{BASE_URL}"};`).
- `GuruBuildManifest` — a bundle with no per-combo assets omits the `env` key; one with per-combo assets populates it.

## Workflow A validation (08 §2, merge precondition)

Local GDU built from this branch and linked into the mfe checkout's root `node_modules/gdu` (dist + entry), replicating `bun gdu:local` but sourced from this worktree.

Reference app: **fmo-users** (tenanted Vite SPA, au+nz). Substituted for the doc's `fls-booking`, which currently fails the Vite 8 build on the pre-existing Rolldown barrel-resolution issue (AG-18800) in its own `generate-quote-button` feature — that failure sits in Rolldown's resolve phase, upstream of and independent of the compat plugins, and reproduces identically under both modes, so it does not exercise the switch. fmo-users resolves the same root gdu and builds clean.

**Default mode** — `NODE_ENV=production APP_ENV=dev_au bun run build:mfe`:
- one un-infixed `mfe-configs-BRHYz_Ev.js` chunk, head baked with `globalThis.__MFE_ENV__={…};`
- no per-combo `mfe-configs-<env>_<tenant>-*.js` scripts
- `build-manifest.json` has no `env` key

(Local `.env.dev_au` resolves real dev values rather than `#{TOKEN}` placeholders — the pipeline's token-config produces the `#{TOKEN}` form through the identical code path, and the unit golden test pins the exact `#{TOKEN}` bytes.)

**Opt-in mode** — `GDU_MULTI_ENV_CONFIG=1 …`:
- un-infixed app chunk head reads `var e=globalThis.__MFE_ENV__.agApiKey,…` — no init block
- 8 per-combo scripts emitted for both tenants (`dev_au, dev_nz, preprod_au, preprod_nz, prod_au, prod_nz, test_au, uat_au`), matching the `.mfe-data` combos
- each per-combo script is a standalone `globalThis.__MFE_ENV__={…}` assignment
- `build-manifest.json` `env` map populated with all 8 combos → their config scripts

## Gates
- `tsc --noEmit` — clean
- Jest (`config/vite`) — green
- eslint (changed files) — 0 errors
