### PR TITLE
fix(AG-20214): GDU multi-env config emitter merges into the env global instead of overwriting

### DIFF
--- a/.changeset/AG-20214-multienv-emitter-merge.md
+++ b/.changeset/AG-20214-multienv-emitter-merge.md
@@ -1,0 +1,36 @@
+---
+'gdu': patch
+---
+
+fix(AG-20214): merge multi-env config seeds instead of clobbering co-mounted apps
+
+`multiEnvConfigEmitter` emitted each per-env/tenant config script as a bare
+`globalThis.__MFE_ENV__={...}` whole-object assignment. On a page that injects
+more than one app's config script — the app-shell Lambda generator, the legacy
+portals, the shadow loader — the second script replaced the first app's
+`globalThis.__MFE_ENV__` outright, so the earlier app lost every one of its
+config keys and fell over on the first read. The divergence is real:
+`mergeConfigSources` layers the global `env-configs/{env}_{tenant}.json` under
+each app's `app-configs/<app>/{env}_{tenant}.json` and then filters to that
+app's `allowKeys`, so two co-mounted apps genuinely carry different key sets.
+
+The emitted seed now merges into any existing global rather than replacing it:
+
+    globalThis.__MFE_ENV__=Object.assign(globalThis.__MFE_ENV__||{},{...});
+
+- The first seed on a page is unchanged. The global starts undefined, `||{}`
+  seeds a fresh object, and the resulting `__MFE_ENV__` is identical to before.
+- A later seed from a second co-mounted app adds its keys instead of wiping the
+  first app's.
+- Overlapping keys stay last-wins. Global-config keys shared across apps carry
+  equal values by construction, so a genuine same-key/different-value clash
+  between two apps' app-configs is a data-layout concern, not something the
+  emitter can resolve.
+- Transition caveat: an old bare-assign artefact built before this release,
+  seeded after a new merge artefact, still clobbers. New artefacts are safe
+  after old ones; the residual case clears as every app rebuilds on this gdu
+  release.
+
+The sibling single-env init block in `mfeEnvTokens.ts` is deliberately left
+untouched — it is byte-locked to the old host + 6-pipeline contract by test, and
+its bare assign is the accepted transition case that ages out as apps rebuild.

--- a/packages/gdu/config/vite/plugins/__tests__/multiEnvConfigEmitter.test.ts
+++ b/packages/gdu/config/vite/plugins/__tests__/multiEnvConfigEmitter.test.ts
@@ -65,6 +65,28 @@ function runGenerateBundle(
 	return emitted;
 }
 
+const SEED_PREFIX =
+	'globalThis.__MFE_ENV__=Object.assign(globalThis.__MFE_ENV__||{},';
+const SEED_SUFFIX = ');';
+
+/**
+ * Mirrors what a browser does when it runs one emitted seed: the seed is
+ * `globalThis.__MFE_ENV__=Object.assign(globalThis.__MFE_ENV__||{},{...})`, so
+ * parsing the payload out of that exact shape (which fails unless the merge form
+ * is intact) and `Object.assign`-ing it onto the running env reproduces the seed
+ * without eval. Feeding `undefined` models the first seed on a fresh page.
+ */
+function applySeed(
+	env: Record<string, unknown> | undefined,
+	source: string,
+): Record<string, unknown> {
+	if (!source.startsWith(SEED_PREFIX) || !source.endsWith(SEED_SUFFIX)) {
+		throw new Error(`seed is not in merge form: ${source}`);
+	}
+	const payload = source.slice(SEED_PREFIX.length, -SEED_SUFFIX.length);
+	return Object.assign(env ?? {}, JSON.parse(payload));
+}
+
 describe('multiEnvConfigEmitter', () => {
 	let root: string;
 	afterEach(() => {
@@ -113,12 +135,81 @@ describe('multiEnvConfigEmitter', () => {
 		const nz = emitted.find((a) => a.fileName.includes('dev_nz'))!;
 
 		expect(au.source).toBe(
-			'globalThis.__MFE_ENV__={"baseUrl":"https://au"};',
+			'globalThis.__MFE_ENV__=Object.assign(globalThis.__MFE_ENV__||{},{"baseUrl":"https://au"});',
 		);
 		expect(nz.source).toBe(
-			'globalThis.__MFE_ENV__={"baseUrl":"https://nz"};',
+			'globalThis.__MFE_ENV__=Object.assign(globalThis.__MFE_ENV__||{},{"baseUrl":"https://nz"});',
 		);
 		expect(au.source).not.toContain('cdkOnly');
+	});
+
+	it('seeds a fresh object when no earlier app has run (first seed on a page)', () => {
+		root = writeWorkspace();
+		const emitted = runGenerateBundle(makePlugin(root), [CONFIG_CHUNK]);
+		const au = emitted.find((a) => a.fileName.includes('dev_au'))!;
+
+		expect(applySeed(undefined, au.source)).toEqual({
+			baseUrl: 'https://au',
+		});
+	});
+
+	it('composes two co-mounted apps so both keep their own keys', () => {
+		root = writeWorkspace();
+		writeFileSync(
+			join(root, '.mfe-data', 'mfe-list.json'),
+			JSON.stringify({
+				spa: {
+					'fls-booking': { au: ['dev'], nz: ['dev'] },
+					'other-app': { au: ['dev'], nz: ['dev'] },
+				},
+			}),
+		);
+		writeFileSync(
+			join(root, '.mfe-data', 'env-configs', 'dev_au.json'),
+			JSON.stringify({
+				baseUrl: 'https://au',
+				apiUrl: 'https://api',
+				cdkOnly: 'x',
+			}),
+		);
+		const first = runGenerateBundle(makePlugin(root), [CONFIG_CHUNK]).find(
+			(a) => a.fileName.includes('dev_au'),
+		)!;
+		const secondPlugin = multiEnvConfigEmitter({
+			appName: '@autoguru/other-app',
+			workspaceRoot: root,
+			envTokenMap: { apiUrl: '"#{API_URL}"' },
+		});
+		const second = runGenerateBundle(secondPlugin, [CONFIG_CHUNK]).find(
+			(a) => a.fileName.includes('dev_au'),
+		)!;
+
+		const env = applySeed(
+			applySeed(undefined, first.source),
+			second.source,
+		);
+
+		expect(env).toEqual({
+			baseUrl: 'https://au',
+			apiUrl: 'https://api',
+		});
+	});
+
+	it('applies last-wins on a key an earlier app already seeded', () => {
+		root = writeWorkspace();
+		const au = runGenerateBundle(makePlugin(root), [CONFIG_CHUNK]).find(
+			(a) => a.fileName.includes('dev_au'),
+		)!;
+
+		const env = applySeed(
+			{ baseUrl: 'https://stale', keep: 'me' },
+			au.source,
+		);
+
+		expect(env).toEqual({
+			baseUrl: 'https://au',
+			keep: 'me',
+		});
 	});
 
 	it('gives each combo a distinct content hash', () => {

--- a/packages/gdu/config/vite/plugins/multiEnvConfigEmitter.ts
+++ b/packages/gdu/config/vite/plugins/multiEnvConfigEmitter.ts
@@ -14,11 +14,22 @@ interface MultiEnvConfigEmitterOptions {
 
 /**
  * Emits one init-only `mfe-configs-<env>_<tenant>-<hash>.js` script per
- * env×tenant combo the app targets, each a standalone
- * `globalThis.__MFE_ENV__={...}` assignment carrying that combo's real, resolved
- * config values. The host injects the combo's script ahead of the app bundle so
- * `globalThis.__MFE_ENV__` is defined before any config read runs (00-overview
- * §4c; 05 host read side).
+ * env×tenant combo the app targets, each an
+ * `globalThis.__MFE_ENV__=Object.assign(globalThis.__MFE_ENV__||{},{...})`
+ * seed carrying that combo's real, resolved config values. The host injects the
+ * combo's script ahead of the app bundle so `globalThis.__MFE_ENV__` is defined
+ * before any config read runs (00-overview §4c; 05 host read side).
+ *
+ * The seed merges into any existing `globalThis.__MFE_ENV__` rather than
+ * replacing it: the first seed on a page behaves identically to a bare assign
+ * (the global starts undefined, so `||{}` seeds a fresh object), while a later
+ * seed from a second co-mounted app ADDS its keys instead of clobbering the
+ * first app's. Overlapping keys are last-wins — global-config keys shared across
+ * apps carry equal values by construction, so a genuine same-key/different-value
+ * clash between two apps' app-configs is a data-layout concern, not one the
+ * emitter can resolve. Ordering caveat: an old bare-assign artefact seeded after
+ * a new merge artefact still clobbers; this resolves as apps rebuild on this gdu
+ * release.
  *
  * The `mfe-configs` chunk itself is left untouched — `mfeEnvTokens` (enforce:
  * 'pre') has already rewritten its `process.env.X` reads to
@@ -72,7 +83,7 @@ export function multiEnvConfigEmitter(
 					tenant,
 					allowKeys,
 				);
-				const source = `globalThis.__MFE_ENV__=${JSON.stringify(values)};`;
+				const source = `globalThis.__MFE_ENV__=Object.assign(globalThis.__MFE_ENV__||{},${JSON.stringify(values)});`;
 				const hash = createHash('sha256')
 					.update(source)
 					.digest('hex')


### PR DESCRIPTION
## What

`multiEnvConfigEmitter` now merges each per-env/tenant config seed into any
existing `globalThis.__MFE_ENV__` instead of assigning the whole object over the
top:

```
globalThis.__MFE_ENV__=Object.assign(globalThis.__MFE_ENV__||{},{...});
```

## Why

Found while supporting the legacy portals. When two UD apps are co-mounted on
one page, each app's config script ran a bare `globalThis.__MFE_ENV__={...}`, so
whichever loaded second replaced the first app's config wholesale and the
earlier app lost all of its keys. This bites every host that injects more than
one app's config script — the app-shell Lambda generator, the legacy portals,
the shadow loader. The per-app divergence is real, not theoretical:
`mergeConfigSources` layers the global `env-configs/{env}_{tenant}.json` under
each app's `app-configs/<app>/{env}_{tenant}.json` and then filters to that
app's `allowKeys`, so two apps genuinely carry different key sets.

## Semantics

- **First seed on a page is unchanged.** The global starts undefined, `||{}`
  seeds a fresh object, and the result is byte-identical to the old bare assign.
- **Later seeds compose.** A second co-mounted app adds its keys rather than
  wiping the first app's.
- **Overlapping keys stay last-wins.** Global-config keys shared across apps
  carry equal values by construction, so a genuine same-key/different-value
  clash between two apps' app-configs is a data-layout concern, not something
  the emitter can resolve.
- **Transition caveat.** An old bare-assign artefact built before this release,
  seeded after a new merge artefact, still clobbers. New artefacts are safe
  after old ones; the residual case clears as every app rebuilds on this gdu
  release.

The sibling single-env init block in `mfeEnvTokens.ts` is left untouched — it's
byte-locked to the old host + 6-pipeline contract by test, and its bare assign
is the accepted transition case that ages out as apps rebuild.

## Tests

Extended `multiEnvConfigEmitter.test.ts`: single-seed shape unchanged,
first-seed bootstrap when `__MFE_ENV__` is undefined, two co-mounted apps
compose (both apps' keys survive), and overlap last-wins. gdu vite + lib suites
green (69 tests).
