### PR TITLE
fix(AG-20532): namespace injected env per app so co-mounted MFEs stop clobbering each other

### DIFF
--- a/.changeset/AG-20532-mfe-env-namespacing.md
+++ b/.changeset/AG-20532-mfe-env-namespacing.md
@@ -1,0 +1,39 @@
+---
+'gdu': minor
+---
+
+fix(AG-20532): namespace the injected env per app so co-mounted MFEs stop clobbering each other
+
+`mfeEnvTokens` and `multiEnvConfigEmitter` wrote every app's config into a
+single flat `globalThis.__MFE_ENV__` object, keyed only by config name. That
+object is shared across every MFE co-mounted on a page, so two apps that read
+the same key — `mfeBasePath` is the load-bearing one — overwrote one another:
+the last config script to load won, and every reader saw its value. On a
+deep-linked supplier-portal child page the scripts load
+`[shell-config, child-config, shell-main, child-main]`, so the shell captured
+the child's relative `mfeBasePath` instead of its own absolute URL and built
+compounding aside-nav hrefs (`/nz/pricing/nz/pricing/...`); child routers then
+stopped matching and rendered blank. The whole `sp-*` family was affected and
+the mechanism is generic to every portal that co-mounts a shell with a child.
+
+The reads and writes are now namespaced under the building app's own name
+(`getProjectName()`):
+
+- `mfeEnvTokens` rewrites `process.env.X` to
+  `globalThis.__MFE_ENV__["<app>"]["X"]`, and its single-env baked init block
+  seeds `globalThis.__MFE_ENV__["<app>"]` via a non-destructive merge that
+  leaves a co-mounted app's namespace intact.
+- `multiEnvConfigEmitter` writes each combo's values under
+  `globalThis.__MFE_ENV__["<app>"]` with the same merge.
+
+Every bundle now reads only its own namespace, so the outcome no longer depends
+on script order. The read-rewrite and both write sites derive the namespace
+from the same `getProjectName()` in one build, so they always agree. The
+`#{TOKEN}`+`sed` deploy contract is unchanged — the placeholders still sit
+inside the namespaced object. Webpack builds constant-fold config into each
+bundle and never touch `__MFE_ENV__`, so they are unaffected; SSR/serverless
+keep their `#{TOKEN}`+`sed` path.
+
+Because the layout of the shared object changes, every app co-mounted on a page
+must be rebuilt on this release together — the release train rebuilds each
+portal family as a unit, so this holds by construction.

--- a/packages/gdu/config/vite/plugins/__tests__/mfeEnvTokens.test.ts
+++ b/packages/gdu/config/vite/plugins/__tests__/mfeEnvTokens.test.ts
@@ -24,15 +24,71 @@ function getRenderChunk(
 	throw new Error('expected renderChunk to be a function hook');
 }
 
+const APP = '@autoguru/sp-pricing';
 const envTokens = {
 	IS_PRODUCTION: '"#{IS_PRODUCTION}"',
 	BASE_URL: '"#{BASE_URL}"',
 };
 
+type MfeEnv = Record<string, Record<string, unknown>>;
+
+// The namespaced seed shape both plugins emit:
+// globalThis.__MFE_ENV__=globalThis.__MFE_ENV__||{};globalThis.__MFE_ENV__[<ns>]=Object.assign(globalThis.__MFE_ENV__[<ns>]||{},<json>);
+const SEED_RE =
+	/^globalThis\.__MFE_ENV__=globalThis\.__MFE_ENV__\|\|\{\};globalThis\.__MFE_ENV__\[("(?:[^"\\]|\\.)*")\]=Object\.assign\(globalThis\.__MFE_ENV__\[\1\]\|\|\{\},(\{.*\})\);$/;
+// A namespaced read: globalThis.__MFE_ENV__[<ns>][<key>]
+const READ_RE =
+	/^globalThis\.__MFE_ENV__\[("(?:[^"\\]|\\.)*")\]\[("(?:[^"\\]|\\.)*")\]$/;
+
+// Applies a seed's runtime effect by parsing its known shape rather than
+// eval-ing it — and asserts the seed really is in the namespaced merge form.
+function applySeed(env: MfeEnv, source: string): MfeEnv {
+	const match = SEED_RE.exec(source);
+	if (!match) throw new Error(`seed not in namespaced merge form: ${source}`);
+	const ns = JSON.parse(match[1]) as string;
+	const values = JSON.parse(match[2]) as Record<string, unknown>;
+	return { ...env, [ns]: { ...env[ns], ...values } };
+}
+
+// Resolves a rewritten read against a seeded env, proving the read and the
+// write agree on the app-name key.
+function readValue(env: MfeEnv, readExpr: string): unknown {
+	const match = READ_RE.exec(readExpr);
+	if (!match) throw new Error(`read is not namespaced: ${readExpr}`);
+	const ns = JSON.parse(match[1]) as string;
+	const key = JSON.parse(match[2]) as string;
+	return env[ns]?.[key];
+}
+
+function seedFor(app: string, mfeBasePath: string): string {
+	const block = getRenderChunk(
+		mfeEnvTokens({ mfeBasePath: JSON.stringify(mfeBasePath) }, app, {
+			bakeInitBlock: true,
+		}),
+	)('', { fileName: 'mfe-configs-1a2b3c4d.js' });
+	if (!block) throw new Error('expected an init block');
+	return block.code;
+}
+
+function readFor(app: string): string {
+	const rewritten = getTransform(
+		mfeEnvTokens({ mfeBasePath: '"#{X}"' }, app),
+	)('process.env.mfeBasePath');
+	if (!rewritten) throw new Error('expected a rewritten read');
+	return rewritten.code;
+}
+
+function loadSeeds(seedsInLoadOrder: string[]): MfeEnv {
+	return seedsInLoadOrder.reduce(
+		(env, seed) => applySeed(env, seed),
+		{} as MfeEnv,
+	);
+}
+
 describe('mfeEnvTokens', () => {
 	describe('when no tokens are provided', () => {
 		it('returns a no-op plugin with only a name', () => {
-			const plugin = mfeEnvTokens({});
+			const plugin = mfeEnvTokens({}, APP);
 			expect(plugin.name).toBe('gdu-mfe-env-tokens');
 			expect(plugin).not.toHaveProperty('transform');
 			expect(plugin).not.toHaveProperty('renderChunk');
@@ -41,37 +97,53 @@ describe('mfeEnvTokens', () => {
 
 	describe('when tokens are provided', () => {
 		it('applies only at build time, before define', () => {
-			const plugin = mfeEnvTokens(envTokens);
+			const plugin = mfeEnvTokens(envTokens, APP);
 			expect(plugin.apply).toBe('build');
 			expect(plugin.enforce).toBe('pre');
 		});
 
-		it('rewrites process.env reads to globalThis.__MFE_ENV__ lookups', () => {
-			const transform = getTransform(mfeEnvTokens(envTokens));
+		it('rewrites process.env reads to the app-namespaced __MFE_ENV__ lookups', () => {
+			const transform = getTransform(mfeEnvTokens(envTokens, APP));
 
 			const result = transform('const a = process.env.BASE_URL;');
 
 			expect(result).toEqual({
-				code: 'const a = globalThis.__MFE_ENV__["BASE_URL"];',
+				code: 'const a = globalThis.__MFE_ENV__["@autoguru/sp-pricing"]["BASE_URL"];',
 				map: null,
 			});
 		});
 
 		it('rewrites every occurrence of every tracked key', () => {
-			const transform = getTransform(mfeEnvTokens(envTokens));
+			const transform = getTransform(mfeEnvTokens(envTokens, APP));
 
 			const result = transform(
 				'a(process.env.BASE_URL);b(process.env.IS_PRODUCTION);c(process.env.BASE_URL);',
 			);
 
 			expect(result).toEqual({
-				code: 'a(globalThis.__MFE_ENV__["BASE_URL"]);b(globalThis.__MFE_ENV__["IS_PRODUCTION"]);c(globalThis.__MFE_ENV__["BASE_URL"]);',
+				code: 'a(globalThis.__MFE_ENV__["@autoguru/sp-pricing"]["BASE_URL"]);b(globalThis.__MFE_ENV__["@autoguru/sp-pricing"]["IS_PRODUCTION"]);c(globalThis.__MFE_ENV__["@autoguru/sp-pricing"]["BASE_URL"]);',
 				map: null,
 			});
 		});
 
+		it('namespaces reads under the building app, so two apps read different keys', () => {
+			const shellRead = getTransform(
+				mfeEnvTokens(envTokens, '@autoguru/sp-app-shell'),
+			)('process.env.BASE_URL');
+			const pricingRead = getTransform(
+				mfeEnvTokens(envTokens, '@autoguru/sp-pricing'),
+			)('process.env.BASE_URL');
+
+			expect(shellRead?.code).toBe(
+				'globalThis.__MFE_ENV__["@autoguru/sp-app-shell"]["BASE_URL"]',
+			);
+			expect(pricingRead?.code).toBe(
+				'globalThis.__MFE_ENV__["@autoguru/sp-pricing"]["BASE_URL"]',
+			);
+		});
+
 		it('does not rewrite keys that are only a prefix of the source token', () => {
-			const transform = getTransform(mfeEnvTokens(envTokens));
+			const transform = getTransform(mfeEnvTokens(envTokens, APP));
 
 			const result = transform('const a = process.env.BASE_URLX;');
 
@@ -79,7 +151,7 @@ describe('mfeEnvTokens', () => {
 		});
 
 		it('leaves untracked process.env keys untouched', () => {
-			const transform = getTransform(mfeEnvTokens(envTokens));
+			const transform = getTransform(mfeEnvTokens(envTokens, APP));
 
 			const result = transform('const a = process.env.NOT_TRACKED;');
 
@@ -87,22 +159,24 @@ describe('mfeEnvTokens', () => {
 		});
 
 		it('returns null when the code has no process.env reads', () => {
-			const transform = getTransform(mfeEnvTokens(envTokens));
+			const transform = getTransform(mfeEnvTokens(envTokens, APP));
 
 			expect(transform('const a = 1;')).toBeNull();
 		});
 	});
 
 	describe('when bakeInitBlock is true (single-env default)', () => {
-		// The exact bytes the old host + 6 old pipelines expect at the head of
-		// the mfe-configs chunk: a globalThis.__MFE_ENV__ assignment carrying the
-		// app's #{TOKEN} placeholders for tokenReplacement.sh to substitute.
+		// The single-env contract: a namespaced, non-destructive
+		// globalThis.__MFE_ENV__["<app>"] seed carrying the app's #{TOKEN}
+		// placeholders for tokenReplacement.sh to substitute. The leading
+		// `||{}` guard keeps a co-mounted app's namespace intact.
 		const expectedInitBlock =
-			'globalThis.__MFE_ENV__={"IS_PRODUCTION":"#{IS_PRODUCTION}","BASE_URL":"#{BASE_URL}"};';
+			'globalThis.__MFE_ENV__=globalThis.__MFE_ENV__||{};' +
+			'globalThis.__MFE_ENV__["@autoguru/sp-pricing"]=Object.assign(globalThis.__MFE_ENV__["@autoguru/sp-pricing"]||{},{"IS_PRODUCTION":"#{IS_PRODUCTION}","BASE_URL":"#{BASE_URL}"});';
 
 		it('prepends the exact init block to the mfe-configs chunk', () => {
 			const renderChunk = getRenderChunk(
-				mfeEnvTokens(envTokens, { bakeInitBlock: true }),
+				mfeEnvTokens(envTokens, APP, { bakeInitBlock: true }),
 			);
 
 			const result = renderChunk('const config = 1;', {
@@ -115,21 +189,23 @@ describe('mfeEnvTokens', () => {
 			});
 		});
 
-		it('leaves the chunk head byte-equal to the old single-env contract', () => {
+		it('preserves the #{TOKEN}+sed contract (globalThis.__MFE_ENV__= assignment present)', () => {
 			const renderChunk = getRenderChunk(
-				mfeEnvTokens(envTokens, { bakeInitBlock: true }),
+				mfeEnvTokens(envTokens, APP, { bakeInitBlock: true }),
 			);
 
 			const result = renderChunk('const config = 1;', {
 				fileName: 'mfe-configs-1a2b3c4d.js',
 			});
 
+			expect(result?.code).toContain('globalThis.__MFE_ENV__=');
+			expect(result?.code).toContain('"#{IS_PRODUCTION}"');
 			expect(result?.code.startsWith(expectedInitBlock)).toBe(true);
 		});
 
 		it('does not bake into chunks other than mfe-configs', () => {
 			const renderChunk = getRenderChunk(
-				mfeEnvTokens(envTokens, { bakeInitBlock: true }),
+				mfeEnvTokens(envTokens, APP, { bakeInitBlock: true }),
 			);
 
 			expect(
@@ -141,7 +217,7 @@ describe('mfeEnvTokens', () => {
 
 		it('does not bake into confusably named chunks under chunks/', () => {
 			const renderChunk = getRenderChunk(
-				mfeEnvTokens(envTokens, { bakeInitBlock: true }),
+				mfeEnvTokens(envTokens, APP, { bakeInitBlock: true }),
 			);
 
 			expect(
@@ -152,15 +228,48 @@ describe('mfeEnvTokens', () => {
 		});
 
 		it('bakes by default when no options are passed (safe default)', () => {
-			const plugin = mfeEnvTokens(envTokens);
+			const plugin = mfeEnvTokens(envTokens, APP);
 			expect(plugin).toHaveProperty('renderChunk');
 		});
 	});
 
 	describe('when bakeInitBlock is false (multi-env opt-in)', () => {
 		it('does not bake an init block into any chunk (owned by multiEnvConfigEmitter)', () => {
-			const plugin = mfeEnvTokens(envTokens, { bakeInitBlock: false });
+			const plugin = mfeEnvTokens(envTokens, APP, {
+				bakeInitBlock: false,
+			});
 			expect(plugin).not.toHaveProperty('renderChunk');
+		});
+	});
+
+	// Reproduces the AG-20532 deep-link failure: two co-mounted apps both read
+	// `mfeBasePath`, the shell an absolute URL, the child a relative router
+	// basename. On the flat layout the last config script to load won for BOTH
+	// readers, so the shell built relative hrefs and nav compounded. Namespacing
+	// makes each bundle read only its own value, whatever the script order.
+	describe('co-mounted apps (no clobber, order-independent)', () => {
+		const SHELL = '@autoguru/sp-app-shell';
+		const CHILD = '@autoguru/sp-pricing';
+		const shellBase = 'https://supplier.preprod.autoguru.com/nz';
+		const childBase = 'nz/pricing';
+
+		it('the shell reads its own absolute base even when the child config loads after it', () => {
+			const env = loadSeeds([
+				seedFor(SHELL, shellBase),
+				seedFor(CHILD, childBase),
+			]);
+
+			expect(readValue(env, readFor(SHELL))).toBe(shellBase);
+		});
+
+		it('is order-independent: reversing the config load order changes nothing', () => {
+			const env = loadSeeds([
+				seedFor(CHILD, childBase),
+				seedFor(SHELL, shellBase),
+			]);
+
+			expect(readValue(env, readFor(SHELL))).toBe(shellBase);
+			expect(readValue(env, readFor(CHILD))).toBe(childBase);
 		});
 	});
 });

--- a/packages/gdu/config/vite/plugins/__tests__/multiEnvConfigEmitter.test.ts
+++ b/packages/gdu/config/vite/plugins/__tests__/multiEnvConfigEmitter.test.ts
@@ -65,26 +65,28 @@ function runGenerateBundle(
 	return emitted;
 }
 
-const SEED_PREFIX =
-	'globalThis.__MFE_ENV__=Object.assign(globalThis.__MFE_ENV__||{},';
-const SEED_SUFFIX = ');';
+type MfeEnv = Record<string, Record<string, unknown>>;
+
+// The namespaced seed shape the emitter produces:
+// globalThis.__MFE_ENV__=globalThis.__MFE_ENV__||{};globalThis.__MFE_ENV__[<ns>]=Object.assign(globalThis.__MFE_ENV__[<ns>]||{},<json>);
+const SEED_RE =
+	/^globalThis\.__MFE_ENV__=globalThis\.__MFE_ENV__\|\|\{\};globalThis\.__MFE_ENV__\[("(?:[^"\\]|\\.)*")\]=Object\.assign\(globalThis\.__MFE_ENV__\[\1\]\|\|\{\},(\{.*\})\);$/;
 
 /**
- * Mirrors what a browser does when it runs one emitted seed: the seed is
- * `globalThis.__MFE_ENV__=Object.assign(globalThis.__MFE_ENV__||{},{...})`, so
- * parsing the payload out of that exact shape (which fails unless the merge form
- * is intact) and `Object.assign`-ing it onto the running env reproduces the seed
- * without eval. Feeding `undefined` models the first seed on a fresh page.
+ * Reproduces one emitted seed's runtime effect by parsing its known shape
+ * (which fails unless the namespaced merge form is intact) and merging the
+ * payload under the app's namespace — no eval. Passing `undefined` models the
+ * first seed on a fresh page.
  */
-function applySeed(
-	env: Record<string, unknown> | undefined,
-	source: string,
-): Record<string, unknown> {
-	if (!source.startsWith(SEED_PREFIX) || !source.endsWith(SEED_SUFFIX)) {
-		throw new Error(`seed is not in merge form: ${source}`);
-	}
-	const payload = source.slice(SEED_PREFIX.length, -SEED_SUFFIX.length);
-	return Object.assign(env ?? {}, JSON.parse(payload));
+function applySeed(env: MfeEnv | undefined, source: string): MfeEnv {
+	const match = SEED_RE.exec(source);
+	if (!match)
+		throw new Error(`seed is not in namespaced merge form: ${source}`);
+	const ns = JSON.parse(match[1]) as string;
+	const values = JSON.parse(match[2]) as Record<string, unknown>;
+	const next: MfeEnv = { ...env };
+	next[ns] = { ...next[ns], ...values };
+	return next;
 }
 
 describe('multiEnvConfigEmitter', () => {
@@ -127,7 +129,7 @@ describe('multiEnvConfigEmitter', () => {
 		]);
 	});
 
-	it('bakes allowlisted, per-combo values with no chunk body', () => {
+	it('bakes allowlisted, per-combo values under the app namespace with no chunk body', () => {
 		root = writeWorkspace();
 		const emitted = runGenerateBundle(makePlugin(root), [CONFIG_CHUNK]);
 
@@ -135,25 +137,25 @@ describe('multiEnvConfigEmitter', () => {
 		const nz = emitted.find((a) => a.fileName.includes('dev_nz'))!;
 
 		expect(au.source).toBe(
-			'globalThis.__MFE_ENV__=Object.assign(globalThis.__MFE_ENV__||{},{"baseUrl":"https://au"});',
+			'globalThis.__MFE_ENV__=globalThis.__MFE_ENV__||{};globalThis.__MFE_ENV__["@autoguru/fls-booking"]=Object.assign(globalThis.__MFE_ENV__["@autoguru/fls-booking"]||{},{"baseUrl":"https://au"});',
 		);
 		expect(nz.source).toBe(
-			'globalThis.__MFE_ENV__=Object.assign(globalThis.__MFE_ENV__||{},{"baseUrl":"https://nz"});',
+			'globalThis.__MFE_ENV__=globalThis.__MFE_ENV__||{};globalThis.__MFE_ENV__["@autoguru/fls-booking"]=Object.assign(globalThis.__MFE_ENV__["@autoguru/fls-booking"]||{},{"baseUrl":"https://nz"});',
 		);
 		expect(au.source).not.toContain('cdkOnly');
 	});
 
-	it('seeds a fresh object when no earlier app has run (first seed on a page)', () => {
+	it('seeds a fresh object under the app namespace when no earlier app has run', () => {
 		root = writeWorkspace();
 		const emitted = runGenerateBundle(makePlugin(root), [CONFIG_CHUNK]);
 		const au = emitted.find((a) => a.fileName.includes('dev_au'))!;
 
 		expect(applySeed(undefined, au.source)).toEqual({
-			baseUrl: 'https://au',
+			'@autoguru/fls-booking': { baseUrl: 'https://au' },
 		});
 	});
 
-	it('composes two co-mounted apps so both keep their own keys', () => {
+	it('keeps each co-mounted app in its own namespace so neither clobbers the other', () => {
 		root = writeWorkspace();
 		writeFileSync(
 			join(root, '.mfe-data', 'mfe-list.json'),
@@ -190,25 +192,72 @@ describe('multiEnvConfigEmitter', () => {
 		);
 
 		expect(env).toEqual({
-			baseUrl: 'https://au',
-			apiUrl: 'https://api',
+			'@autoguru/fls-booking': { baseUrl: 'https://au' },
+			'@autoguru/other-app': { apiUrl: 'https://api' },
 		});
 	});
 
-	it('applies last-wins on a key an earlier app already seeded', () => {
+	it('does not clobber a co-mounted app that seeds the SAME key with a different value', () => {
+		root = writeWorkspace();
+		writeFileSync(
+			join(root, '.mfe-data', 'mfe-list.json'),
+			JSON.stringify({
+				spa: {
+					'fls-booking': { au: ['dev'], nz: ['dev'] },
+					'other-app': { au: ['dev'], nz: ['dev'] },
+				},
+			}),
+		);
+		// Both apps read `baseUrl`, but the app-config overrides give them
+		// different values — the exact shape that clobbered under the flat layout.
+		mkdirSync(join(root, '.mfe-data', 'app-configs', 'other-app'), {
+			recursive: true,
+		});
+		writeFileSync(
+			join(root, '.mfe-data', 'app-configs', 'other-app', 'dev_au.json'),
+			JSON.stringify({ baseUrl: 'https://other' }),
+		);
+		const first = runGenerateBundle(makePlugin(root), [CONFIG_CHUNK]).find(
+			(a) => a.fileName.includes('dev_au'),
+		)!;
+		const secondPlugin = multiEnvConfigEmitter({
+			appName: '@autoguru/other-app',
+			workspaceRoot: root,
+			envTokenMap: { baseUrl: '"#{BASE_URL}"' },
+		});
+		const second = runGenerateBundle(secondPlugin, [CONFIG_CHUNK]).find(
+			(a) => a.fileName.includes('dev_au'),
+		)!;
+
+		const env = applySeed(
+			applySeed(undefined, first.source),
+			second.source,
+		);
+
+		expect(env['@autoguru/fls-booking'].baseUrl).toBe('https://au');
+		expect(env['@autoguru/other-app'].baseUrl).toBe('https://other');
+	});
+
+	it('applies last-wins within a namespace without touching other namespaces', () => {
 		root = writeWorkspace();
 		const au = runGenerateBundle(makePlugin(root), [CONFIG_CHUNK]).find(
 			(a) => a.fileName.includes('dev_au'),
 		)!;
 
 		const env = applySeed(
-			{ baseUrl: 'https://stale', keep: 'me' },
+			{
+				'@autoguru/fls-booking': {
+					baseUrl: 'https://stale',
+					keep: 'me',
+				},
+				'@autoguru/sp-app-shell': { mfeBasePath: 'https://shell' },
+			},
 			au.source,
 		);
 
 		expect(env).toEqual({
-			baseUrl: 'https://au',
-			keep: 'me',
+			'@autoguru/fls-booking': { baseUrl: 'https://au', keep: 'me' },
+			'@autoguru/sp-app-shell': { mfeBasePath: 'https://shell' },
 		});
 	});
 

--- a/packages/gdu/config/vite/plugins/mfeEnvTokens.ts
+++ b/packages/gdu/config/vite/plugins/mfeEnvTokens.ts
@@ -2,11 +2,12 @@ import type { VitePlugin } from '../types';
 
 export interface MfeEnvTokensOptions {
 	/**
-	 * When true (the safe default), the plugin prepends a
-	 * `globalThis.__MFE_ENV__["<app>"]={...#{TOKEN}...}` init block to the
-	 * `mfe-configs` chunk — the single-env contract the old host + 6 old
-	 * pipelines expect (`tokenReplacement.sh`/`sed` substitute the `#{TOKEN}`
-	 * placeholders at deploy time). When false, no init block is baked and
+	 * When true (the safe default), the plugin prepends a namespaced,
+	 * non-destructive init block that merges this app's `#{TOKEN}` placeholders
+	 * into `globalThis.__MFE_ENV__["<app>"]` at the head of the `mfe-configs`
+	 * chunk — the single-env contract the old host + 6 old pipelines expect
+	 * (`tokenReplacement.sh`/`sed` substitute the `#{TOKEN}` placeholders at
+	 * deploy time). When false, no init block is baked and
 	 * `globalThis.__MFE_ENV__["<app>"]` is instead initialised by the per-combo
 	 * scripts `multiEnvConfigEmitter` emits (04-gdu-vite8.md §2.8).
 	 */

--- a/packages/gdu/config/vite/plugins/mfeEnvTokens.ts
+++ b/packages/gdu/config/vite/plugins/mfeEnvTokens.ts
@@ -3,19 +3,19 @@ import type { VitePlugin } from '../types';
 export interface MfeEnvTokensOptions {
 	/**
 	 * When true (the safe default), the plugin prepends a
-	 * `globalThis.__MFE_ENV__={...#{TOKEN}...}` init block to the `mfe-configs`
-	 * chunk — the single-env contract the old host + 6 old pipelines expect
-	 * (`tokenReplacement.sh`/`sed` substitute the `#{TOKEN}` placeholders at
-	 * deploy time). When false, no init block is baked and `globalThis.__MFE_ENV__`
-	 * is instead initialised by the per-combo scripts `multiEnvConfigEmitter`
-	 * emits (04-gdu-vite8.md §2.8).
+	 * `globalThis.__MFE_ENV__["<app>"]={...#{TOKEN}...}` init block to the
+	 * `mfe-configs` chunk — the single-env contract the old host + 6 old
+	 * pipelines expect (`tokenReplacement.sh`/`sed` substitute the `#{TOKEN}`
+	 * placeholders at deploy time). When false, no init block is baked and
+	 * `globalThis.__MFE_ENV__["<app>"]` is instead initialised by the per-combo
+	 * scripts `multiEnvConfigEmitter` emits (04-gdu-vite8.md §2.8).
 	 */
 	bakeInitBlock?: boolean;
 }
 
 /**
- * Rewrites `process.env.XXX` reads to `globalThis.__MFE_ENV__["XXX"]` so
- * per-env/tenant config can be injected as a separate chunk rather than
+ * Rewrites `process.env.XXX` reads to `globalThis.__MFE_ENV__["<app>"]["XXX"]`
+ * so per-env/tenant config can be injected as a separate chunk rather than
  * constant-folded into application code.
  *
  * Problem: Vite's `define` replaces `process.env.XXX` with a string literal.
@@ -24,12 +24,20 @@ export interface MfeEnvTokensOptions {
  * time.
  *
  * Solution: This plugin runs before `define` (`enforce: 'pre'`) and rewrites
- * `process.env.XXX` → `globalThis.__MFE_ENV__["XXX"]`. Dynamic property access
- * cannot be constant-folded, so every config read resolves through a single
+ * `process.env.XXX` → `globalThis.__MFE_ENV__["<app>"]["XXX"]`. Dynamic property
+ * access cannot be constant-folded, so every config read resolves through the
  * `globalThis.__MFE_ENV__` object at runtime, keeping application chunk bytes
  * independent of which env's values are in play.
  *
- * How `globalThis.__MFE_ENV__` is initialised depends on the build mode
+ * The reads are namespaced under the building app's own name (`appName`). The
+ * `globalThis.__MFE_ENV__` object is shared across every MFE co-mounted on a
+ * page, so a flat `__MFE_ENV__["XXX"]` layout let two apps writing the same key
+ * (e.g. `mfeBasePath`) clobber one another — last script loaded wins, and an
+ * earlier app read the later app's value. Namespacing each app's config under
+ * `__MFE_ENV__["<app>"]` makes every bundle read only its own values, so the
+ * outcome no longer depends on script order (AG-20532).
+ *
+ * How `globalThis.__MFE_ENV__["<app>"]` is initialised depends on the build mode
  * (04-gdu-vite8.md §2.8). In the default single-env contract (`bakeInitBlock`
  * true) the plugin's `renderChunk` prepends the init block to the `mfe-configs`
  * chunk. In multi-env mode (`bakeInitBlock` false) `multiEnvConfigEmitter` emits
@@ -38,6 +46,7 @@ export interface MfeEnvTokensOptions {
  */
 export function mfeEnvTokens(
 	envTokens: Record<string, string>,
+	appName: string,
 	options: MfeEnvTokensOptions = {},
 ): VitePlugin {
 	const { bakeInitBlock = true } = options;
@@ -54,10 +63,16 @@ export function mfeEnvTokens(
 		'g',
 	);
 
+	const ns = JSON.stringify(appName);
 	const initEntries = keys
 		.map((key) => `${JSON.stringify(key)}:${envTokens[key]}`)
 		.join(',');
-	const initCode = `globalThis.__MFE_ENV__={${initEntries}};`;
+	// Namespaced, non-destructive seed: create the shared object if absent
+	// (never replacing an existing one, so a co-mounted app's namespace
+	// survives), then merge this app's values under its own key.
+	const initCode =
+		`globalThis.__MFE_ENV__=globalThis.__MFE_ENV__||{};` +
+		`globalThis.__MFE_ENV__[${ns}]=Object.assign(globalThis.__MFE_ENV__[${ns}]||{},{${initEntries}});`;
 
 	return {
 		name: 'gdu-mfe-env-tokens',
@@ -69,7 +84,8 @@ export function mfeEnvTokens(
 
 			const result = code.replace(
 				pattern,
-				(_, key) => `globalThis.__MFE_ENV__[${JSON.stringify(key)}]`,
+				(_, key) =>
+					`globalThis.__MFE_ENV__[${ns}][${JSON.stringify(key)}]`,
 			);
 
 			return result === code ? null : { code: result, map: null };

--- a/packages/gdu/config/vite/plugins/multiEnvConfigEmitter.ts
+++ b/packages/gdu/config/vite/plugins/multiEnvConfigEmitter.ts
@@ -14,26 +14,24 @@ interface MultiEnvConfigEmitterOptions {
 
 /**
  * Emits one init-only `mfe-configs-<env>_<tenant>-<hash>.js` script per
- * env×tenant combo the app targets, each an
- * `globalThis.__MFE_ENV__=Object.assign(globalThis.__MFE_ENV__||{},{...})`
- * seed carrying that combo's real, resolved config values. The host injects the
- * combo's script ahead of the app bundle so `globalThis.__MFE_ENV__` is defined
- * before any config read runs (00-overview §4c; 05 host read side).
+ * env×tenant combo the app targets, each a
+ * `globalThis.__MFE_ENV__["<app>"]=Object.assign(...)` seed carrying that
+ * combo's real, resolved config values under the app's own namespace. The host
+ * injects the combo's script ahead of the app bundle so
+ * `globalThis.__MFE_ENV__["<app>"]` is defined before any config read runs
+ * (00-overview §4c; 05 host read side).
  *
- * The seed merges into any existing `globalThis.__MFE_ENV__` rather than
- * replacing it: the first seed on a page behaves identically to a bare assign
- * (the global starts undefined, so `||{}` seeds a fresh object), while a later
- * seed from a second co-mounted app ADDS its keys instead of clobbering the
- * first app's. Overlapping keys are last-wins — global-config keys shared across
- * apps carry equal values by construction, so a genuine same-key/different-value
- * clash between two apps' app-configs is a data-layout concern, not one the
- * emitter can resolve. Ordering caveat: an old bare-assign artefact seeded after
- * a new merge artefact still clobbers; this resolves as apps rebuild on this gdu
- * release.
+ * The seed is namespaced per app and non-destructive on both levels: it creates
+ * the shared `globalThis.__MFE_ENV__` object if absent (never replacing an
+ * existing one, so a co-mounted app's namespace survives) and merges this app's
+ * values under `["<app>"]`. Because each app writes and reads only its own
+ * namespace, two co-mounted apps that share a config key (e.g. `mfeBasePath`)
+ * no longer clobber one another regardless of script order — the AG-20532 fix
+ * for the flat layout, where the last-loaded app's value won for every reader.
  *
  * The `mfe-configs` chunk itself is left untouched — `mfeEnvTokens` (enforce:
  * 'pre') has already rewritten its `process.env.X` reads to
- * `globalThis.__MFE_ENV__.X`, so it is env-agnostic (identical bytes for every
+ * `globalThis.__MFE_ENV__["<app>"].X`, so it is env-agnostic (identical bytes for every
  * combo) and, crucially, still exports the config bindings that the rest of the
  * app graph imports. Only the tiny init scripts differ per combo, so one build
  * pass yields one env-agnostic app bundle plus N small config scripts whose
@@ -83,7 +81,10 @@ export function multiEnvConfigEmitter(
 					tenant,
 					allowKeys,
 				);
-				const source = `globalThis.__MFE_ENV__=Object.assign(globalThis.__MFE_ENV__||{},${JSON.stringify(values)});`;
+				const ns = JSON.stringify(opts.appName);
+				const source =
+					`globalThis.__MFE_ENV__=globalThis.__MFE_ENV__||{};` +
+					`globalThis.__MFE_ENV__[${ns}]=Object.assign(globalThis.__MFE_ENV__[${ns}]||{},${JSON.stringify(values)});`;
 				const hash = createHash('sha256')
 					.update(source)
 					.digest('hex')

--- a/packages/gdu/config/vite/plugins/multiEnvConfigEmitter.ts
+++ b/packages/gdu/config/vite/plugins/multiEnvConfigEmitter.ts
@@ -31,8 +31,8 @@ interface MultiEnvConfigEmitterOptions {
  *
  * The `mfe-configs` chunk itself is left untouched — `mfeEnvTokens` (enforce:
  * 'pre') has already rewritten its `process.env.X` reads to
- * `globalThis.__MFE_ENV__["<app>"].X`, so it is env-agnostic (identical bytes for every
- * combo) and, crucially, still exports the config bindings that the rest of the
+ * `globalThis.__MFE_ENV__["<app>"]["X"]`, so it is env-agnostic (identical bytes for
+ * every combo) and, crucially, still exports the config bindings that the rest of the
  * app graph imports. Only the tiny init scripts differ per combo, so one build
  * pass yields one env-agnostic app bundle plus N small config scripts whose
  * bytes depend solely on that combo's values. `guruBuildManifest` records the
@@ -73,6 +73,7 @@ export function multiEnvConfigEmitter(
 				return;
 			}
 
+			const ns = JSON.stringify(opts.appName);
 			for (const { env, tenant } of combos) {
 				const values = mergeConfigSources(
 					opts.workspaceRoot,
@@ -81,7 +82,6 @@ export function multiEnvConfigEmitter(
 					tenant,
 					allowKeys,
 				);
-				const ns = JSON.stringify(opts.appName);
 				const source =
 					`globalThis.__MFE_ENV__=globalThis.__MFE_ENV__||{};` +
 					`globalThis.__MFE_ENV__[${ns}]=Object.assign(globalThis.__MFE_ENV__[${ns}]||{},${JSON.stringify(values)});`;

--- a/packages/gdu/config/vite/vite.config.ts
+++ b/packages/gdu/config/vite/vite.config.ts
@@ -121,6 +121,9 @@ export const baseViteOptions = ({
 
 	const envDefines = loadEnvDefines(buildEnv);
 	const { envTokenMap } = buildEnvTokenMap(envDefines);
+	// Single source for the __MFE_ENV__ namespace so the read-rewrite
+	// (mfeEnvTokens) and the write (multiEnvConfigEmitter) key on the same app.
+	const appName = getProjectName();
 
 	return {
 		resolve: {
@@ -144,7 +147,8 @@ export const baseViteOptions = ({
 			__GDU_APP_NAME__: JSON.stringify(getProjectName()),
 			__GDU_BUILD_INFO__: JSON.stringify({ commit, branch }),
 			// In production builds, mfeEnvTokens (enforce: 'pre') rewrites
-			// process.env.X to globalThis.__MFE_ENV__["X"] before `define` runs
+			// process.env.X to globalThis.__MFE_ENV__["<app>"]["X"] before
+			// `define` runs
 			// (the __MFE_ENV__ object is initialised either by the baked init
 			// block in the single-env default or by multiEnvConfigEmitter's
 			// per-combo scripts when multiEnvConfig is set — 04-gdu-vite8.md
@@ -214,11 +218,13 @@ export const baseViteOptions = ({
 			// Runtime plugins (vanillaExtractPlugin, tsconfigPaths, relayPlugin) are
 			// injected by buildSPA-vite.ts and runSPA-vite.ts to avoid tsc dependency on vite.
 			overdriveBarrelSplit(),
-			mfeEnvTokens(envTokenMap, { bakeInitBlock: !multiEnvConfig }),
+			mfeEnvTokens(envTokenMap, appName, {
+				bakeInitBlock: !multiEnvConfig,
+			}),
 			...(multiEnvConfig
 				? [
 						multiEnvConfigEmitter({
-							appName: getProjectName(),
+							appName,
 							workspaceRoot:
 								CALLING_WORKSPACE_ROOT ?? PROJECT_ROOT,
 							envTokenMap,

--- a/packages/gdu/config/vite/vite.config.ts
+++ b/packages/gdu/config/vite/vite.config.ts
@@ -144,7 +144,7 @@ export const baseViteOptions = ({
 			__MOUNT_DOM_ID__: JSON.stringify(guruConfig.mountDOMId),
 			__MOUNT_DOM_CLASS__: JSON.stringify(guruConfig.mountDOMClass),
 			__DEBUG__: JSON.stringify(false),
-			__GDU_APP_NAME__: JSON.stringify(getProjectName()),
+			__GDU_APP_NAME__: JSON.stringify(appName),
 			__GDU_BUILD_INFO__: JSON.stringify({ commit, branch }),
 			// In production builds, mfeEnvTokens (enforce: 'pre') rewrites
 			// process.env.X to globalThis.__MFE_ENV__["<app>"]["X"] before


### PR DESCRIPTION
## What's going on

Co-mounted MFEs all share one `globalThis.__MFE_ENV__` object, and until now it was flat, with every app's config keyed only by config name. So when two apps on the same page read the same key, they trod on each other. Whichever config script loaded last won, and every reader got that value. `mfeBasePath` is the one that bites, because the shell uses an absolute URL for its aside-nav links while a child like sp-pricing uses a relative router basename.

On a deep-linked child page the scripts load in the order `[shell-config, child-config, shell-main, child-main]`, so by the time the shell's main bundle read `mfeBasePath` it got the child's relative value. That's why the shell built compounding hrefs (`/nz/pricing/nz/pricing/...`) and the child routers stopped matching and rendered blank. The whole `sp-*` family was hit, and the mechanism is generic to any portal that co-mounts a shell with a child (fmo, fcp and de-portal share it).

## The fix

Namespace the injected env per app. Reads and writes now key on `globalThis.__MFE_ENV__["<app>"]`, where the app name is `getProjectName()`. Both write sites, the single-env baked init block in `mfeEnvTokens` and the per-combo scripts in `multiEnvConfigEmitter`, seed with a non-destructive merge so a co-mounted app's namespace survives no matter the load order. The read-rewrite and both writes take the app name from the same `getProjectName()` in one build, so they can't disagree on the key.

Because each bundle now reads only its own namespace, script order stops mattering and the clobber is gone.

## Scope and back-compat

- Vite only. The webpack path constant-folds config into each bundle and never touches `__MFE_ENV__`, so it's unaffected. SSR/serverless keep their `#{TOKEN}`+sed path.
- The `#{TOKEN}`+sed deploy contract is intact. The placeholders still sit inside the namespaced object, and the `globalThis.__MFE_ENV__=` assignment text that sed keys on is still there.
- The shared object's shape changes from flat to namespaced, so every app co-mounted on a page has to be rebuilt on this release together. The release train rebuilds each portal family as a unit, so that holds by construction. Prod builds should stay held until the family is rebuilt on this gdu.

## Tests

Both plugins get unit coverage for the namespaced shape, plus the cases that matter: the co-load no-clobber, order-independence (the shell reads its own absolute base even when the child config loads after it), read/write key agreement, and the same-key/different-value case that reproduces the original `mfeBasePath` clash. The tests parse the seed's shape rather than eval it, so they fail if the fix is reverted.

`gdu` jest suite green (101 tests), `tsc --noEmit` clean, lint clean.

Changeset: minor.
